### PR TITLE
Phase 1: governance docs and quality script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,26 @@ See `.env.example` for the public-safe configuration contract.
 
 All variables prefixed with `NEXT_PUBLIC_` are exposed to the browser. Do not place secrets, tokens, private endpoints, or sensitive values in `NEXT_PUBLIC_*`.
 
-## Governance (Current State)
+## Governance (Implemented)
 
-At this stage, this repo provides the baseline application skeleton and content structure.
+Phase 1 governance is enforced:
 
-Next steps (planned):
+- Required CI checks with stable names:
+  - `ci / quality` (lint, format:check, typecheck)
+  - `ci / build` (Next.js build; depends on quality)
+- Deterministic installs in CI: `pnpm install --frozen-lockfile`
+- Supply chain and static analysis: CodeQL (JS/TS) and Dependabot (weekly; majors excluded)
 
-- Enforce PR discipline with required CI checks (lint/format/typecheck/build)
-- Add CodeQL and dependency governance (Dependabot)
-- Deploy to Vercel with preview deployments and production promotion gated by checks
+### Local quality contract
+
+Run locally before pushing:
+
+```bash
+pnpm lint
+pnpm format:check
+pnpm typecheck
+pnpm build
+```
 
 ## Deployment (planned)
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
+    "quality": "pnpm lint && pnpm format:check && pnpm typecheck",
     "format:check": "prettier --check .",
     "format:write": "prettier --write ."
   },


### PR DESCRIPTION
This PR updates portfolio-app governance docs and adds a local quality script.\n\nChanges:\n- README: mark governance as Implemented; list required checks: `ci / quality`, `ci / build`; note frozen installs; CodeQL + Dependabot; add local quality contract snippet.\n- package.json: add `quality` script (lint, format:check, typecheck).\n\nWhy:\n- Aligns repository with Phase 1 Definition of Done (roadmap).\n\nValidation:\n- Prettier check passes.\n- CI should run `ci / quality` and `ci / build` with frozen installs.\n\nFollow-up (out-of-repo):\n- Ensure GitHub Ruleset enforces required checks; configure Vercel previews + promotion checks.