### PR TITLE
ci: auto-format Dependabot PRs and ignore lockfiles in Prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -35,6 +35,18 @@ jobs:
 
       - name: Install (frozen)
         run: pnpm install --frozen-lockfile
+
+      - name: Auto-format for Dependabot PRs
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        run: |
+          pnpm format:write || true
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: auto-format (CI)"
+            git push
+          fi
 
       - name: Lint
         run: pnpm lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ node_modules
 coverage
 .vercel
 notes.md
+pnpm-lock.yaml
+package-lock.json
+yarn.lock


### PR DESCRIPTION
This PR hardens CI against Dependabot-related quality failures.\n\nChanges:\n- Set workflow permissions to contents: write (for CI to push formatting changes)\n- Add a Dependabot-only auto-format step before quality checks\n- Add pnpm-lock.yaml (and other lockfiles) to .prettierignore\n\nWhy:\n- Prevents Prettier failures on machine-generated lockfiles\n- Allows Dependabot PRs to pass quality without manual intervention\n\nSafety:\n- Auto-format only runs when github.actor == 'dependabot[bot]'\n- No behavior change for human PRs\n