### PR TITLE
fix: restrict secrets-scan to pull requests only (fixes TruffleHog BASE==HEAD issue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     name: secrets-scan
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Only run on pull requests where a real diff exists (avoids TruffleHog BASE==HEAD issue on push)
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
 
@@ -87,7 +89,10 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [quality, secrets-scan]
+    # Require quality job; secrets-scan is optional (only on PRs)
+    needs: [quality]
+    # Allow skipping when secrets-scan is conditional (not run on push events)
+    if: always() && needs.quality.result == 'success'
     # Phase 2 Enhancement: Least-privilege permissions (contents: read only)
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fixes CI workflow failures caused by TruffleHog secrets scanning on push events.

## Problem

The `secrets-scan` job was failing on push events to `main` with the error:
```
BASE and HEAD commits are the same. TruffleHog won't scan anything.
```

This occurs because TruffleHog requires a diff between base and head commits, but on direct pushes to main, both are the same commit.

## Solution

Restrict the secrets-scan job to run only on **pull_request** events where a real diff exists:
- Added conditional: `if: github.event_name == 'pull_request'` to secrets-scan job
- Updated build job to only depend on 'quality' job (secrets-scan is optional)
- Added resilience condition to build job: `if: always() && needs.quality.result == 'success'`

## Impact

- ✅ Secrets scanning still enforced on all PRs (where diffs exist)
- ✅ Push events to main no longer fail
- ✅ No security regression (all code changes go through PRs per branch protection rules)
- ✅ Phase 2 security controls remain intact

## Testing

- [ ] Push to main should now succeed (quality + build jobs only)
- [ ] PRs should still run secrets-scan + quality + build
- [ ] CodeQL scanning unaffected (runs on separate trigger)

## Refs

- Phase 2 Information Disclosure mitigation (secrets-scan gate)
- Threat Model: https://bns-portfolio-docs.vercel.app/docs/security/threat-models/portfolio-app-threat-model
- Compliance Report: https://bns-portfolio-docs.vercel.app/docs/security/threat-models/portfolio-app-stride-compliance-report