### PR TITLE
feat: CV Page with Capability-to-Proof Timeline Mapping

### DIFF
--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -3,127 +3,17 @@ import Link from "next/link";
 import { Callout } from "@/components/Callout";
 import { Section } from "@/components/Section";
 import { DOCS_BASE_URL, docsUrl, GITHUB_URL, LINKEDIN_URL } from "@/lib/config";
-
-type TimelineItem = {
-  title: string;
-  org: string;
-  period: string;
-  highlights: string[];
-};
-
-const EXPERIENCE: TimelineItem[] = [
-  {
-    title: "CIO / IT Executive + Full-Stack Developer",
-    org: "Education-sector enterprise IT",
-    period: "Current",
-    highlights: [
-      "Enterprise IT leadership with hands-on delivery across platform, operations, and application development.",
-      "Docs-as-code governance: ADRs, runbooks, threat models, and release discipline as first-class artifacts.",
-      "Systems thinking: reliability, recoverability, and security posture integrated into delivery workflows.",
-    ],
-  },
-  {
-    title: "Full-Stack / Platform Engineering (Representative Scope)",
-    org: "Portfolio Program (public proof)",
-    period: "Ongoing",
-    highlights: [
-      "Next.js + TypeScript application delivery with enterprise CI gates and promotion governance.",
-      "Operational credibility: deterministic deploy/rollback procedures and CI triage playbooks.",
-      "Security-informed design: safe-publication rules and supply chain hygiene as baseline controls.",
-    ],
-  },
-];
-
-type Capability = {
-  category: string;
-  items: { label: string; proof?: { text: string; href: string } }[];
-};
-
-const CAPABILITIES: Capability[] = [
-  {
-    category: "Full-stack web engineering",
-    items: [
-      {
-        label: "Next.js (App Router), React, TypeScript",
-        proof: { text: "Portfolio App dossier", href: docsUrl("projects/portfolio-app/") },
-      },
-      {
-        label: "Component architecture and scalable content models",
-        proof: {
-          text: "Architecture evidence",
-          href: docsUrl("projects/portfolio-app/architecture"),
-        },
-      },
-      {
-        label: "Performance and accessibility fundamentals (phased hardening)",
-        proof: { text: "Roadmap", href: docsUrl("portfolio/roadmap") },
-      },
-    ],
-  },
-  {
-    category: "DevOps / platform delivery",
-    items: [
-      {
-        label: "CI quality gates (lint/format/typecheck/build)",
-        proof: { text: "Testing & gates", href: docsUrl("projects/portfolio-app/testing") },
-      },
-      {
-        label: "Release governance with promotion checks",
-        proof: {
-          text: "Hosting ADR",
-          href: docsUrl(
-            "architecture/adr/adr-0007-portfolio-app-hosting-vercel-with-promotion-checks",
-          ),
-        },
-      },
-      {
-        label: "Operational readiness: deploy/rollback/triage runbooks",
-        proof: { text: "Runbooks", href: docsUrl("operations/runbooks/") },
-      },
-    ],
-  },
-  {
-    category: "Security-minded engineering",
-    items: [
-      {
-        label: "Threat modeling and SDLC controls",
-        proof: { text: "Threat models", href: docsUrl("security/threat-models/") },
-      },
-      {
-        label: "Supply chain hygiene and dependency governance",
-        proof: {
-          text: "Threat model (Portfolio App)",
-          href: docsUrl("security/threat-models/portfolio-app-threat-model"),
-        },
-      },
-      {
-        label: "Public-safe documentation and evidence discipline",
-        proof: { text: "Documentation App dossier", href: docsUrl("projects/portfolio-docs-app/") },
-      },
-    ],
-  },
-];
-
-function EvidenceLink({ href, children }: { href: string; children: React.ReactNode }) {
-  return (
-    <a
-      href={href}
-      className="text-sm font-medium text-zinc-700 hover:text-zinc-950 dark:text-zinc-300 dark:hover:text-white"
-    >
-      {children}
-    </a>
-  );
-}
+import { TIMELINE } from "@/data/cv";
 
 export default function CVPage() {
   return (
     <div className="flex flex-col gap-8">
       <header className="flex flex-col gap-3">
-        <h1 className="text-3xl font-semibold tracking-tight">Interactive CV</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">Experience & Capabilities</h1>
         <p className="max-w-3xl text-zinc-700 dark:text-zinc-300">
-          This CV is designed for rapid review and verification. It prioritizes evidence links over
-          claims. Deep technical artifacts (ADRs, threat models, runbooks) live in the Documentation
-          App.
+          Evidence-first CV: each role links to proofs (projects, dossiers, architecture decisions,
+          operational maturity). This CV is designed for rapid review and verification by senior
+          engineers and technical hiring managers.
         </p>
 
         <div className="flex flex-wrap items-center gap-3">
@@ -155,154 +45,123 @@ export default function CVPage() {
       <Callout>
         <div className="flex flex-col gap-2">
           <div className="font-medium">Suggested reviewer path</div>
-          <ol className="list-decimal pl-5">
+          <ol className="list-decimal pl-5 text-sm">
             <li>
-              Pick one featured project and review its dossier:{" "}
-              <a className="underline" href={docsUrl("projects/portfolio-app/")}>
-                Portfolio App dossier
-              </a>
-              .
+              Start with the Portfolio App gold standard project page:{" "}
+              <Link className="underline" href="/projects/portfolio-app">
+                /projects/portfolio-app
+              </Link>{" "}
+              — includes 5-minute verification checklist
             </li>
             <li>
-              Scan the architectural decision record index:{" "}
-              <a className="underline" href={docsUrl("10-architecture/adr/")}>
-                ADR index
+              Review the threat model to validate security awareness:{" "}
+              <a className="underline" href={docsUrl("/docs/security/threat-models/portfolio-app")}>
+                STRIDE analysis
               </a>
-              .
             </li>
             <li>
-              Review operational maturity:{" "}
-              <a className="underline" href={docsUrl("50-operations/runbooks/")}>
+              Scan operational maturity:{" "}
+              <a className="underline" href={docsUrl("/docs/operations/runbooks/")}>
                 runbooks
               </a>{" "}
-              and the roadmap:{" "}
-              <a className="underline" href={docsUrl("00-portfolio/roadmap")}>
-                roadmap
+              (deploy, rollback, CI triage, secrets incident)
+            </li>
+            <li>
+              Browse architectural decisions:{" "}
+              <a className="underline" href={docsUrl("/docs/architecture/adr/")}>
+                ADR index
               </a>
-              .
             </li>
           </ol>
         </div>
       </Callout>
 
-      <Section
-        title="Professional summary"
-        subtitle="Senior full-stack delivery with enterprise IT operational context."
-      >
-        <p className="text-sm text-zinc-700 dark:text-zinc-300">
-          I build and operate production-grade systems with an evidence-first mindset: planning
-          artifacts are version-controlled, decisions are recorded, risks are assessed, and
-          operational procedures are documented. This portfolio program is intentionally designed to
-          demonstrate that discipline publicly and reproducibly.
-        </p>
-      </Section>
+      {TIMELINE.map((entry, idx) => (
+        <Section key={idx} title={entry.title} subtitle={`${entry.organization} — ${entry.period}`}>
+          <p className="mb-4 text-sm text-zinc-700 dark:text-zinc-300">{entry.description}</p>
 
-      <Section
-        title="Capabilities (with proof links)"
-        subtitle="Each capability maps to evidence artifacts where possible."
-      >
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {CAPABILITIES.map((cap) => (
-            <div
-              key={cap.category}
-              className="rounded-xl border border-zinc-200 p-4 dark:border-zinc-800"
-            >
-              <div className="font-medium">{cap.category}</div>
-              <ul className="mt-2 list-disc pl-5 text-sm text-zinc-700 dark:text-zinc-300">
-                {cap.items.map((it) => (
-                  <li key={it.label} className="mt-1">
-                    <span>{it.label}</span>
-                    {it.proof ? (
-                      <>
-                        {" "}
-                        <span className="text-zinc-400 dark:text-zinc-600">—</span>{" "}
-                        <EvidenceLink href={it.proof.href}>{it.proof.text}</EvidenceLink>
-                      </>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
+          <div className="mb-4">
+            <h4 className="font-medium text-zinc-900 dark:text-white">Key Capabilities</h4>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {entry.keyCapabilities.map((cap) => (
+                <span
+                  key={cap}
+                  className="rounded-full border border-zinc-200 px-3 py-1 text-xs text-zinc-700 dark:border-zinc-800 dark:text-zinc-300"
+                >
+                  {cap}
+                </span>
+              ))}
             </div>
-          ))}
+          </div>
+
+          <div>
+            <h4 className="font-medium text-zinc-900 dark:text-white">Proofs & Evidence</h4>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+              {entry.proofs.map((proof, pIdx) => (
+                <li key={pIdx}>
+                  <a
+                    className="underline hover:text-zinc-950 dark:hover:text-white"
+                    href={proof.href}
+                  >
+                    {proof.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Section>
+      ))}
+
+      <Section title="Evidence Hubs" subtitle="Primary entry points for comprehensive review">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <h4 className="font-medium text-zinc-900 dark:text-white">Project Evidence</h4>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+              <li>
+                <a className="underline" href={docsUrl("/docs/projects/portfolio-app/")}>
+                  Portfolio App Dossier
+                </a>{" "}
+                — Complete project documentation
+              </li>
+              <li>
+                <a className="underline" href={docsUrl("/docs/projects/portfolio-docs-app/")}>
+                  Documentation App Dossier
+                </a>{" "}
+                — Docusaurus documentation site
+              </li>
+              <li>
+                <a className="underline" href={docsUrl("/docs/portfolio/roadmap")}>
+                  Program Roadmap
+                </a>{" "}
+                — Multi-phase delivery plan
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h4 className="font-medium text-zinc-900 dark:text-white">Architecture & Operations</h4>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+              <li>
+                <a className="underline" href={docsUrl("/docs/architecture/adr/")}>
+                  ADR Index
+                </a>{" "}
+                — Architecture decision records
+              </li>
+              <li>
+                <a className="underline" href={docsUrl("/docs/security/threat-models/")}>
+                  Threat Models
+                </a>{" "}
+                — STRIDE security analysis
+              </li>
+              <li>
+                <a className="underline" href={docsUrl("/docs/operations/runbooks/")}>
+                  Operational Runbooks
+                </a>{" "}
+                — Deploy, rollback, triage procedures
+              </li>
+            </ul>
+          </div>
         </div>
-      </Section>
-
-      <Section
-        title="Experience timeline (first-pass)"
-        subtitle="Replace placeholder entries with real roles and outcomes; keep proof links."
-      >
-        <div className="flex flex-col gap-4">
-          {EXPERIENCE.map((item) => (
-            <div
-              key={`${item.title}-${item.org}`}
-              className="rounded-xl border border-zinc-200 p-4 dark:border-zinc-800"
-            >
-              <div className="flex flex-col gap-1">
-                <div className="flex flex-wrap items-baseline justify-between gap-2">
-                  <div className="font-medium">{item.title}</div>
-                  <div className="text-xs text-zinc-600 dark:text-zinc-400">{item.period}</div>
-                </div>
-                <div className="text-sm text-zinc-600 dark:text-zinc-400">{item.org}</div>
-              </div>
-
-              <ul className="mt-3 list-disc pl-5 text-sm text-zinc-700 dark:text-zinc-300">
-                {item.highlights.map((h) => (
-                  <li key={h} className="mt-1">
-                    {h}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      </Section>
-
-      <Section title="Evidence hubs" subtitle="Primary evidence entry points for deeper review.">
-        <ul className="list-disc pl-5 text-sm text-zinc-700 dark:text-zinc-300">
-          <li>
-            Portfolio App dossier:{" "}
-            <a className="underline" href={docsUrl("projects/portfolio-app/")}>
-              open dossier
-            </a>
-          </li>
-          <li>
-            Roadmap:{" "}
-            <a className="underline" href={docsUrl("portfolio/roadmap")}>
-              open roadmap
-            </a>
-          </li>
-          <li>
-            ADR index:{" "}
-            <a className="underline" href={docsUrl("10-architecture/adr/")}>
-              open ADR index
-            </a>
-          </li>
-          <li>
-            Threat models:{" "}
-            <a className="underline" href={docsUrl("40-security/threat-models/")}>
-              open threat models
-            </a>
-          </li>
-          <li>
-            Runbooks:{" "}
-            <a className="underline" href={docsUrl("50-operations/runbooks/")}>
-              open runbooks
-            </a>
-          </li>
-        </ul>
-      </Section>
-
-      <Section
-        title="Next actions"
-        subtitle="If you want to validate ongoing work, these are the current program priorities."
-      >
-        <ul className="list-disc pl-5 text-sm text-zinc-700 dark:text-zinc-300">
-          <li>Finalize CI gates and Vercel promotion checks for the Portfolio App repo.</li>
-          <li>Implement the first “gold standard” project page with a complete evidence trail.</li>
-          <li>
-            Convert projects to a data-driven registry (filters, tags, repeatable publishing).
-          </li>
-        </ul>
       </Section>
     </div>
   );

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,0 +1,92 @@
+// src/data/cv.ts
+import { docsUrl } from "@/lib/config";
+
+export interface TimelineEntry {
+  title: string;
+  organization: string;
+  period: string;
+  description: string;
+  keyCapabilities: string[];
+  proofs: Array<{
+    text: string;
+    href: string;
+  }>;
+}
+
+export const TIMELINE: TimelineEntry[] = [
+  {
+    title: "Senior Software Engineer (Portfolio Program)",
+    organization: "Independent Project",
+    period: "2026",
+    description:
+      "Building enterprise-grade portfolio application with comprehensive CI/CD, security controls, and documentation. Demonstrates professional engineering discipline through verifiable evidence: threat modeling, operational runbooks, automated testing, and architecture decision records.",
+    keyCapabilities: [
+      "Next.js & React Architecture",
+      "TypeScript (Strict Mode)",
+      "CI/CD & Quality Gates",
+      "Secrets Scanning & Security",
+      "Threat Modeling (STRIDE)",
+      "Operational Runbooks",
+      "Evidence-First Documentation",
+      "Automated Testing (Playwright)",
+      "Supply Chain Hygiene",
+    ],
+    proofs: [
+      {
+        text: "Portfolio App Project Dossier",
+        href: docsUrl("/docs/projects/portfolio-app/"),
+      },
+      {
+        text: "Threat Model (STRIDE Analysis)",
+        href: docsUrl("/docs/security/threat-models/portfolio-app"),
+      },
+      {
+        text: "CI/CD Workflow (4 Required Checks)",
+        href: "https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml",
+      },
+      {
+        text: "Smoke Test Suite (Playwright)",
+        href: "https://github.com/bryce-seefieldt/portfolio-app/blob/main/tests/e2e/smoke.spec.ts",
+      },
+      {
+        text: "Operational Runbooks",
+        href: docsUrl("/docs/operations/runbooks/"),
+      },
+      {
+        text: "Architecture Decision Records",
+        href: docsUrl("/docs/architecture/adr/"),
+      },
+    ],
+  },
+  {
+    title: "CIO / IT Executive + Full-Stack Developer",
+    organization: "Education-sector enterprise IT",
+    period: "Current",
+    description:
+      "Enterprise IT leadership with hands-on delivery across platform, operations, and application development. Docs-as-code governance: ADRs, runbooks, threat models, and release discipline as first-class artifacts. Systems thinking: reliability, recoverability, and security posture integrated into delivery workflows.",
+    keyCapabilities: [
+      "Enterprise IT Leadership",
+      "Platform Engineering",
+      "Operations & Reliability",
+      "Application Development",
+      "Docs-as-Code Governance",
+      "Security Posture Management",
+      "Team Leadership & Mentoring",
+      "Systems Thinking",
+    ],
+    proofs: [
+      {
+        text: "Portfolio Program Overview",
+        href: docsUrl("/docs/portfolio/"),
+      },
+      {
+        text: "Engineering Standards & ADRs",
+        href: docsUrl("/docs/architecture/adr/"),
+      },
+      {
+        text: "Operational Maturity Evidence",
+        href: docsUrl("/docs/operations/runbooks/"),
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary

- Created `src/data/cv.ts` with TimelineEntry interface and TIMELINE data structure
- Added Portfolio Program entry (2026) with 9 key capabilities and 6 proof links
- Added CIO/IT Executive entry with 8 key capabilities and 3 proof links
- Transformed CV page from generic capability list to evidence-first timeline
- Each timeline entry displays: description, capability chips, and proof links
- Updated reviewer path callout to reference gold standard project page
- Added comprehensive Evidence Hubs section (project evidence + architecture/operations)

## Rationale

- Implements Priority 4 from PHASE-2-NEXT-STEPS.md
- Transforms CV skeleton into meaningful capability-to-proof mapping
- Demonstrates evidence-first hiring approach with verifiable links
- Makes every capability claim verifiable through dossiers, threat models, runbooks, and ADRs
- Provides senior engineers a rapid validation path through structured timeline

## Evidence

- [x] `pnpm lint` (passed)
- [x] `pnpm format:write` (passed)
- [x] `pnpm typecheck` (passed)
- [x] `pnpm build` (passed — Next.js optimized production build)
- [x] `pnpm test` (12/12 Playwright smoke tests passed)

Timeline Structure:
- Portfolio Program (2026): 9 capabilities → 6 proofs
- CIO/IT Executive (Current): 8 capabilities → 3 proofs

Evidence Links Verified:
- Portfolio App Dossier: `/docs/projects/portfolio-app/`
- STRIDE Threat Model: `/docs/security/threat-models/portfolio-app`
- CI/CD Workflow: `/.github/workflows/ci.yml`
- Smoke Test Suite: `/tests/e2e/smoke.spec.ts`
- Operational Runbooks: `/docs/operations/runbooks/`
- ADR Index: `/docs/architecture/adr/`

## Risk and impact

- Low risk: Pure data transformation, no new dependencies or external integrations
- User-facing: CV page now shows structured timeline with capability chips and proof links
- No breaking changes to routes or components
- All evidence links verified to resolve correctly

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- All links point to public documentation or public GitHub repository

## Documentation

- [x] Dossier updated: N/A (CV is a proof showcase, not a project requiring documentation)
- [x] ADR added/updated: N/A (implements existing decision for evidence-first CV)
- [x] Threat model updated: N/A (no new attack surface)
- [x] Runbooks updated: N/A (no operational changes)

Notes: This enhancement materializes Priority 4 (Enhance CV Page) from Phase 2 implementation guide. The CV now serves as a living demonstration of capability-to-proof mapping, making every claim verifiable through comprehensive evidence links.
