### PR TITLE
refactor: Centralize All URLs Using Environment Variable Helpers

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { Section } from "@/components/Section";
 import { Callout } from "@/components/Callout";
 import { GoldStandardBadge } from "@/components/GoldStandardBadge";
 import { getProjectBySlug } from "@/data/projects";
-import { docsUrl } from "@/lib/config";
+import { docsUrl, githubUrl } from "@/lib/config";
 
 export default async function ProjectDetailPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
@@ -105,10 +105,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
             <div className="mt-4 flex flex-col gap-3 text-sm text-zinc-700 dark:text-zinc-300">
               <div>
                 <strong>Enforced quality gates:</strong> Open{" "}
-                <a
-                  className="underline"
-                  href="https://github.com/cdoremus/portfolio-app/blob/main/.github/workflows/ci.yml"
-                >
+                <a className="underline" href={githubUrl("blob/main/.github/workflows/ci.yml")}>
                   .github/workflows/ci.yml
                 </a>{" "}
                 → see <code>quality</code>, <code>secrets-scan</code>, <code>build-and-test</code>,{" "}
@@ -117,10 +114,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
               <div>
                 <strong>PR discipline:</strong> Open{" "}
-                <a
-                  className="underline"
-                  href="https://github.com/cdoremus/portfolio-app/settings/branches"
-                >
+                <a className="underline" href={githubUrl("settings/branches")}>
                   Branch Protection
                 </a>{" "}
                 → confirm require-PR + status-checks enabled.
@@ -140,7 +134,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
               <div>
                 <strong>Smoke tests:</strong> Check{" "}
-                <a className="underline" href="https://github.com/cdoremus/portfolio-app/actions">
+                <a className="underline" href={githubUrl("actions")}>
                   recent CI runs
                 </a>{" "}
                 → see Playwright smoke tests passing post-build.
@@ -148,10 +142,7 @@ export default async function ProjectDetailPage({ params }: { params: Promise<{ 
 
               <div>
                 <strong>Dependencies:</strong> Open{" "}
-                <a
-                  className="underline"
-                  href="https://github.com/cdoremus/portfolio-app/blob/main/package.json"
-                >
+                <a className="underline" href={githubUrl("blob/main/package.json")}>
                   package.json
                 </a>{" "}
                 → see Next 15+, React 19, Tailwind 4, TypeScript 5.

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,5 +1,5 @@
 // src/data/cv.ts
-import { docsUrl } from "@/lib/config";
+import { docsUrl, githubUrl } from "@/lib/config";
 
 export interface TimelineEntry {
   title: string;
@@ -42,11 +42,11 @@ export const TIMELINE: TimelineEntry[] = [
       },
       {
         text: "CI/CD Workflow (4 Required Checks)",
-        href: "https://github.com/bryce-seefieldt/portfolio-app/blob/main/.github/workflows/ci.yml",
+        href: githubUrl("blob/main/.github/workflows/ci.yml"),
       },
       {
         text: "Smoke Test Suite (Playwright)",
-        href: "https://github.com/bryce-seefieldt/portfolio-app/blob/main/tests/e2e/smoke.spec.ts",
+        href: githubUrl("blob/main/tests/e2e/smoke.spec.ts"),
       },
       {
         text: "Operational Runbooks",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -4,6 +4,8 @@
 // This intentionally starts small and static so the app can scale cleanly later.
 // Do not store secrets or sensitive/internal data here.
 
+import { DOCS_BASE_URL, DOCS_GITHUB_URL, GITHUB_URL } from "@/lib/config";
+
 export type EvidenceLinks = {
   dossierPath?: string; // Docusaurus path relative to DOCS_BASE_URL, e.g. "projects/portfolio-app/"
   threatModelPath?: string; // e.g. "security/threat-models/portfolio-app-threat-model"
@@ -30,8 +32,8 @@ export const PROJECTS: Project[] = [
       "Production-quality portfolio application designed to be reviewed like a real service (CI gates, release governance, security posture).",
     tags: ["TypeScript", "Next.js", "Vercel", "CI/CD", "Security", "Docs-as-code"],
     status: "featured",
-    repoUrl: "", // add once repo URL is finalized/published
-    demoUrl: "", // add once domain is live
+    repoUrl: GITHUB_URL || undefined,
+    demoUrl: undefined, // Will be set once production domain is finalized
     evidence: {
       dossierPath: "projects/portfolio-app/",
       threatModelPath: "security/threat-models/portfolio-app-threat-model",
@@ -46,8 +48,8 @@ export const PROJECTS: Project[] = [
       "Enterprise documentation platform hosting dossiers, ADRs, threat models, runbooks, and release notes for the portfolio program.",
     tags: ["Docusaurus", "Docs-as-code", "Vercel", "Governance", "Operations"],
     status: "featured",
-    repoUrl: "", // add once repo URL is finalized/published
-    demoUrl: "", // add once docs URL is live (DOCS_BASE_URL)
+    repoUrl: DOCS_GITHUB_URL || undefined,
+    demoUrl: DOCS_BASE_URL || undefined,
     evidence: {
       dossierPath: "projects/portfolio-docs-app/",
       adrIndexPath: "architecture/adr/",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,7 @@ type Env = {
 
   // Optional public links
   NEXT_PUBLIC_GITHUB_URL?: string;
+  NEXT_PUBLIC_DOCS_GITHUB_URL?: string;
   NEXT_PUBLIC_LINKEDIN_URL?: string;
   NEXT_PUBLIC_CONTACT_EMAIL?: string;
 
@@ -68,6 +69,7 @@ export const DOCS_BASE_URL: string = normalizeBaseUrl(
  * Public profile links (optional). Prefer these over hardcoding URLs in components.
  */
 export const GITHUB_URL: string | null = asAbsoluteUrl(env.NEXT_PUBLIC_GITHUB_URL);
+export const DOCS_GITHUB_URL: string | null = asAbsoluteUrl(env.NEXT_PUBLIC_DOCS_GITHUB_URL);
 export const LINKEDIN_URL: string | null = asAbsoluteUrl(env.NEXT_PUBLIC_LINKEDIN_URL);
 
 /**
@@ -88,6 +90,26 @@ export function docsUrl(pathname: string): string {
   // Accept "foo/bar", "/foo/bar", or "".
   const p = pathname.replace(/^\/+/, "");
   return p ? `${DOCS_BASE_URL}/${p}` : DOCS_BASE_URL;
+}
+
+export function githubUrl(pathname: string): string {
+  // Build URL from GITHUB_URL with optional path
+  if (!GITHUB_URL) {
+    console.warn("GITHUB_URL not configured, returning placeholder");
+    return "#";
+  }
+  const p = pathname.replace(/^\/+/, "");
+  return p ? `${GITHUB_URL}/${p}` : GITHUB_URL;
+}
+
+export function docsGithubUrl(pathname: string): string {
+  // Build URL from DOCS_GITHUB_URL with optional path
+  if (!DOCS_GITHUB_URL) {
+    console.warn("DOCS_GITHUB_URL not configured, returning placeholder");
+    return "#";
+  }
+  const p = pathname.replace(/^\/+/, "");
+  return p ? `${DOCS_GITHUB_URL}/${p}` : DOCS_GITHUB_URL;
 }
 
 export function mailtoUrl(email: string, subject?: string): string {


### PR DESCRIPTION
## Summary

This PR replaces all hardcoded GitHub URLs with environment variable-based helpers for consistency, maintainability, and correctness.

## Problems Fixed

- **Critical:** Hardcoded GitHub username `cdoremus` in project detail page (should be `bryce-seefieldt`)
- 6 hardcoded GitHub URLs across 2 files (projects/[slug]/page.tsx, data/cv.ts)
- Empty `repoUrl`/`demoUrl` fields in projects.ts (now populated from env vars)
- Missing `NEXT_PUBLIC_DOCS_GITHUB_URL` support in config.ts

## Changes

### 1. [src/lib/config.ts](src/lib/config.ts)
- Add `NEXT_PUBLIC_DOCS_GITHUB_URL` to Env type
- Export `DOCS_GITHUB_URL` constant
- Add `githubUrl()` helper for portfolio-app GitHub URLs
- Add `docsGithubUrl()` helper for portfolio-docs GitHub URLs

### 2. [src/app/projects/[slug]/page.tsx](src/app/projects/[slug]/page.tsx)
- Import `githubUrl` helper
- Replace 4 hardcoded GitHub URLs:
  - CI workflow (.github/workflows/ci.yml)
  - Branch protection settings (settings/branches)
  - Actions page (actions)
  - Package.json (blob/main/package.json)
- **Fix username from `cdoremus` to correct `bryce-seefieldt` via env var**

### 3. [src/data/cv.ts](src/data/cv.ts)
- Import `githubUrl` helper
- Replace 2 hardcoded GitHub URLs:
  - CI workflow (blob/main/.github/workflows/ci.yml)
  - Smoke test suite (blob/main/tests/e2e/smoke.spec.ts)

### 4. [src/data/projects.ts](src/data/projects.ts)
- Import `GITHUB_URL`, `DOCS_GITHUB_URL`, `DOCS_BASE_URL` from config
- Populate portfolio-app `repoUrl` from `GITHUB_URL`
- Populate portfolio-docs-app `repoUrl` from `DOCS_GITHUB_URL`
- Populate portfolio-docs-app `demoUrl` from `DOCS_BASE_URL`

## Benefits

- ✅ Single source of truth for all URLs (.env.local)
- ✅ Easy to update URLs across entire codebase
- ✅ Type-safe URL construction with helper functions
- ✅ Eliminates hardcoded username errors
- ✅ Consistent URL formatting (trailing slash normalization)

## Validation

- ✅ `pnpm lint` (ESLint passed)
- ✅ `pnpm format:write` (Prettier passed)
- ✅ `pnpm typecheck` (TypeScript strict mode passed)
- ✅ `pnpm build` (Next.js production build successful)
- ✅ `pnpm test` (12/12 Playwright smoke tests passed)

## Impact

All URLs now derive from environment variables in .env.local, ensuring correctness and enabling easy configuration across environments (local, preview, production).

## Type

- [x] Refactor
- [x] Bug fix (hardcoded username)
- [x] Enhancement (URL helpers)