### PR TITLE
test: enhance documentation/structure for link construction helpe…

### DIFF
--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,7 +1,8 @@
 // src/lib/__tests__/config.test.ts
-//
-// Unit tests for link construction helpers (docsUrl, githubUrl, docsGithubUrl, mailtoUrl).
 
+/* 
+Unit tests for link construction helpers (docsUrl, githubUrl, docsGithubUrl, mailtoUrl).
+*/
 import { describe, it, expect } from "vitest";
 import {
   DOCS_BASE_URL,
@@ -31,8 +32,8 @@ describe("Link Construction Helpers", () => {
     });
 
     it("should handle nested paths", () => {
-      const result = docsUrl("portfolio/roadmap/issues/stage-3-1");
-      expect(result).toBe(`${DOCS_BASE_URL}/portfolio/roadmap/issues/stage-3-1`);
+      const result = docsUrl("portfolio/features");
+      expect(result).toBe(`${DOCS_BASE_URL}/portfolio/features`);
     });
 
     it("should work with single leading slash", () => {


### PR DESCRIPTION
## Summary
This pull request makes a minor update to the unit tests for link construction helpers. The main change is updating the test for nested paths to use a different example path.

* Testing improvements:
  * Updated the `docsUrl` nested path test case to use `"portfolio/features"` instead of `"portfolio/roadmap/issues/stage-3-1"`, ensuring test coverage for a simpler nested path.

* Documentation cleanup:
  * Replaced the comment header with a block comment for clarity and consistency in the test file.

## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [ ] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [x] `ci / quality` passed (lint, format, typecheck)
- [x] `ci / secrets-scan` passed (PR-only gate)
- [x] `ci / test` passed (unit + E2E tests)
- [x] `ci / link-validation` passed (registry + evidence links; Stage 3.5)
- [x] `ci / build` passed (depends on quality, test, link-validation)
- [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)
- Notes:
