### PR TITLE
Add commentary to unit tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,6 +69,7 @@ Before proposing changes, review and internalize the existing architecture and c
 - Use the import alias `@/*` for internal imports (configured in `tsconfig.json`).
 - Keep route pages simple and reviewer-focused. Deep technical details belong in the Documentation App.
 - Prefer small, composable components under `src/components/`.
+- Follow the code commentary standard: https://bns-portfolio-docs.vercel.app/docs/engineering/commentary-standard (examples: https://bns-portfolio-docs.vercel.app/docs/reference/commentary-examples).
 
 **Phase status:** Phase 3 Stages 3.1–3.3 are complete (registry, evidence components, unit/E2E coverage integrated into CI); Stage 3.4 documentation alignment is next.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Enterprise-grade documentation is hosted separately to preserve a clean product 
 
 - Docs base URL is configured via: `NEXT_PUBLIC_DOCS_BASE_URL`
 - The code constructs evidence links through: `src/lib/config.ts`
+- Code commentary standard: https://bns-portfolio-docs.vercel.app/docs/engineering/commentary-standard (examples: https://bns-portfolio-docs.vercel.app/docs/reference/commentary-examples)
 
 ## Tech stack
 

--- a/src/app/projects/[slug]/__tests__/metadata.test.ts
+++ b/src/app/projects/[slug]/__tests__/metadata.test.ts
@@ -1,19 +1,21 @@
 // src/app/projects/[slug]/__tests__/metadata.test.ts
 //
 // Unit tests for project page metadata generation.
-// Verifies that generateMetadata returns correct structure with project details,
-// Open Graph metadata, and Twitter Card configuration.
+// RATIONALE: Metadata is the primary SEO/social contract for project pages; regressions are visible externally.
+// FAILURE MODE: Missing or malformed metadata degrades previews and discovery.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Metadata } from "next";
 import type { Project } from "@/lib/registry";
 import { getProjectBySlug } from "@/data/projects";
 
+// ASSUMPTION: Metadata behavior is deterministic given a project registry entry.
 // Mock the data/projects module
 vi.mock("@/data/projects", () => ({
   getProjectBySlug: vi.fn(),
 }));
 
+// ASSUMPTION: SITE_URL is a stable base for canonical/OG URLs in tests.
 // Mock the config module
 vi.mock("@/lib/config", () => ({
   SITE_URL: "https://example.com",
@@ -24,7 +26,7 @@ import * as ProjectModule from "@/app/projects/[slug]/page";
 
 /**
  * Helper to create a valid mock Project object for testing.
- * Provides sensible defaults for required fields.
+ * RATIONALE: Centralizes required fields to reduce test noise and keep intent focused on metadata assertions.
  */
 function createMockProject(overrides: Partial<Project> = {}): Project {
   const defaults: Project = {
@@ -53,6 +55,7 @@ describe("Project Page Metadata", () => {
     });
 
     it("should return fallback metadata when project not found", async () => {
+      // FAILURE MODE: Unregistered slugs must produce safe, user-friendly metadata.
       const mockGetProjectBySlug = vi.mocked(getProjectBySlug);
       mockGetProjectBySlug.mockReturnValue(undefined);
 
@@ -96,6 +99,7 @@ describe("Project Page Metadata", () => {
     });
 
     describe("Open Graph metadata", () => {
+      // RATIONALE: Social previews depend on Open Graph fields and must be consistent across projects.
       it("should include Open Graph object", async () => {
         const mockProject = createMockProject({
           title: "Portfolio App",
@@ -187,6 +191,7 @@ describe("Project Page Metadata", () => {
     });
 
     describe("Twitter Card metadata", () => {
+      // RATIONALE: Twitter cards mirror Open Graph expectations; missing fields cause degraded previews.
       it("should include twitter object", async () => {
         const mockProject = createMockProject();
 

--- a/src/lib/__tests__/config-variants.test.ts
+++ b/src/lib/__tests__/config-variants.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+// RATIONALE: Config parsing hardens public-safe URL inputs and prevents malformed links.
+// FAILURE MODE: Invalid base URLs propagate into evidence links and metadata.
 describe("config variants", () => {
   it("should fall back to null for invalid site URL", async () => {
     process.env.NEXT_PUBLIC_SITE_URL = "not-a-url";
@@ -11,6 +13,7 @@ describe("config variants", () => {
   });
 
   it("should normalize trailing slashes in configured URLs", async () => {
+    // ASSUMPTION: Normalized URLs avoid double-slash regressions in link helpers.
     process.env.NEXT_PUBLIC_SITE_URL = "https://example.com/";
     process.env.NEXT_PUBLIC_DOCS_BASE_URL = "https://docs.example.com/";
     vi.resetModules();

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,7 +1,9 @@
 // src/lib/__tests__/config.test.ts
 
-/* 
+/*
 Unit tests for link construction helpers (docsUrl, githubUrl, docsGithubUrl, mailtoUrl).
+RATIONALE: Link helpers enforce evidence-first navigation without hardcoding environment-specific URLs.
+FAILURE MODE: Misconstructed links break reviewer paths and evidence discovery.
 */
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/__tests__/environment.test.ts
+++ b/src/lib/__tests__/environment.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import * as config from "../config";
 import * as environment from "../environment";
 
+// RATIONALE: The environment module is a stable facade; re-exports must remain consistent.
 describe("environment re-exports", () => {
   it("should re-export config constants and helpers", () => {
     expect(environment.ENVIRONMENT).toBe(config.ENVIRONMENT);

--- a/src/lib/__tests__/linkConstruction.test.ts
+++ b/src/lib/__tests__/linkConstruction.test.ts
@@ -1,6 +1,8 @@
 // src/lib/__tests__/linkConstruction.test.ts
 //
 // Unit tests for link construction helpers (docsUrl, githubUrl, docsGithubUrl, mailtoUrl).
+// RATIONALE: Evidence links must be deterministic across local, preview, and production environments.
+// FAILURE MODE: A broken helper leaks bad URLs into the UI and evidence registry.
 
 import { describe, it, expect } from "vitest";
 import {

--- a/src/lib/__tests__/observability.test.ts
+++ b/src/lib/__tests__/observability.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { log, logError } from "../observability";
 
+// OPS: Structured logs are the primary audit trail in serverless environments.
+// ASSUMPTION: Timestamp and environment fields are required for downstream triage.
 describe("observability", () => {
   const originalEnv = process.env.VERCEL_ENV;
 

--- a/src/lib/__tests__/registry-cli.test.ts
+++ b/src/lib/__tests__/registry-cli.test.ts
@@ -19,6 +19,8 @@ vi.mock("js-yaml", () => ({
 }));
 
 describe("registry CLI", () => {
+  // RATIONALE: CLI output drives CI verification and human triage for registry integrity.
+  // FAILURE MODE: Non-zero exit codes must surface on validation errors.
   const mockProject: Project = {
     slug: "portfolio-app",
     title: "Portfolio App",
@@ -75,6 +77,7 @@ describe("registry CLI", () => {
   });
 
   it("should return non-zero status on failure", async () => {
+    // FAILURE MODE: Load failures must fail CI and print diagnostics.
     const registry = await import("../registry");
 
     const status = registry.runRegistryCli("", {
@@ -97,6 +100,7 @@ describe("registry CLI", () => {
   });
 
   it("should report error messages for Error instances", async () => {
+    // ASSUMPTION: Errors are surfaced as human-readable messages for CI logs.
     const registry = await import("../registry");
 
     const status = registry.runRegistryCli("", {

--- a/src/lib/__tests__/registry-functions.test.ts
+++ b/src/lib/__tests__/registry-functions.test.ts
@@ -18,6 +18,8 @@ vi.mock("js-yaml", () => ({
 }));
 
 describe("registry helpers", () => {
+  // RATIONALE: Registry helpers normalize data so UI and validation share the same contract.
+  // FAILURE MODE: Bad interpolation or caching creates inconsistent evidence links.
   beforeEach(() => {
     mockExistsSync.mockReset().mockReturnValue(true);
     mockReadFileSync.mockReset().mockReturnValue("fake");
@@ -150,6 +152,7 @@ describe("registry helpers", () => {
   });
 
   it("should generate evidence links and validation warnings", async () => {
+    // SECURITY: Evidence paths must follow safe, predictable patterns to avoid link injection.
     mockYamlLoad.mockReturnValue([
       {
         slug: "portfolio-app",
@@ -179,6 +182,7 @@ describe("registry helpers", () => {
   });
 
   it("should null out unresolved placeholders", async () => {
+    // FAILURE MODE: Empty env vars should not leak placeholder strings into rendered links.
     process.env.NEXT_PUBLIC_GITHUB_URL = "";
     process.env.NEXT_PUBLIC_DOCS_GITHUB_URL = "";
     process.env.NEXT_PUBLIC_SITE_URL = "";

--- a/src/lib/__tests__/registry.test.ts
+++ b/src/lib/__tests__/registry.test.ts
@@ -1,6 +1,7 @@
 // src/lib/__tests__/registry.test.ts
 //
 // Unit tests for registry validation, slug rules, and schema enforcement.
+// RATIONALE: Schema validation is the first line of defense against broken evidence data.
 
 import { describe, it, expect } from "vitest";
 import { ProjectSchema, TechStackItemSchema, EvidenceLinksSchema } from "../registry";

--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -3,6 +3,7 @@ import { BASE_SECURITY_HEADERS, buildCsp } from "@/lib/security/headers";
 import { generateCsrfToken, validateCsrf } from "@/lib/security/csrf";
 import { rateLimit } from "@/lib/security/ratelimit";
 
+// SECURITY: These tests harden the public surface by enforcing headers, CSRF, and rate limits.
 describe("security headers", () => {
   it("should include core security headers", () => {
     const headerMap = new Map(BASE_SECURITY_HEADERS);
@@ -26,6 +27,7 @@ describe("security headers", () => {
 });
 
 describe("csrf utilities", () => {
+  // SECURITY: CSRF validation must fail closed when tokens are missing or mismatched.
   it("should generate a unique token", () => {
     const first = generateCsrfToken();
     const second = generateCsrfToken();
@@ -62,6 +64,7 @@ describe("csrf utilities", () => {
 });
 
 describe("rate limiter", () => {
+  // SECURITY: Rate limits reduce abuse risk and protect shared resources.
   it("should enforce limits and reset after window", () => {
     vi.useFakeTimers();
     const now = new Date("2026-02-05T00:00:00.000Z");

--- a/src/lib/__tests__/slugHelpers.test.ts
+++ b/src/lib/__tests__/slugHelpers.test.ts
@@ -1,9 +1,11 @@
 // src/lib/__tests__/slugHelpers.test.ts
 //
 // Unit tests for slug validation and helper functions.
+// RATIONALE: Slugs are part of public URLs; strict validation avoids routing ambiguity.
 
 import { describe, it, expect } from "vitest";
 
+// ASSUMPTION: Regex mirrors registry validation to keep routing and data contracts aligned.
 // Slug validation regex from registry.ts
 // eslint-disable-next-line security/detect-unsafe-regex -- bounded, linear slug matcher.
 const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
@@ -96,6 +98,7 @@ describe("Slug Helpers", () => {
     });
 
     it("should not accept null or undefined", () => {
+      // FAILURE MODE: Regex-only validation allows coerced values; type guards must handle this upstream.
       // null and undefined will be coerced to strings by REGEX.test()
       // null -> "null" (which matches the slug pattern, so returns true)
       // undefined -> "undefined" (which matches the slug pattern, so returns true)

--- a/src/lib/__tests__/structured-data.test.ts
+++ b/src/lib/__tests__/structured-data.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+// RATIONALE: Structured data improves SEO and must remain stable across environments.
+// FAILURE MODE: Missing schema links reduce search visibility and rich results.
 describe("structured data", () => {
   it("should build person schema with sameAs links when configured", async () => {
     process.env.NEXT_PUBLIC_SITE_URL = "https://example.com";
@@ -44,6 +46,7 @@ describe("structured data", () => {
   });
 
   it("should fall back to example.com when SITE_URL is missing", async () => {
+    // ASSUMPTION: Fallback URL avoids generating invalid schema when env vars are absent.
     process.env.NEXT_PUBLIC_SITE_URL = "";
     vi.resetModules();
 


### PR DESCRIPTION
## Summary

- What changed?
  - Added rationale-focused commentary across unit tests per the commentary standard.
  - Linked the commentary standard in README and Copilot instructions.

## Rationale

- Why was this change made?
  - Align test commentary with the self-documenting standard and reduce review ambiguity.
- What requirement or issue does it address?
  - Commentary standard adoption for portfolio-app tests and guidance.

## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional): Not run.

## Risk and impact

- What could break?
  - Low risk; comments only.
- Any user-facing changes?
  - No.

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [ ] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [x] `ci / quality` passed (lint, format, typecheck)
- [x] `ci / secrets-scan` passed (PR-only gate)
- [x] `ci / test` passed (unit + E2E tests)
- [x] `ci / link-validation` passed (registry + evidence links; Stage 3.5)
- [x] `ci / build` passed (depends on quality, test, link-validation)
- [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)
- Notes:
