### PR TITLE
docs(copilot): add dependabot PR CI remediation reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,6 +138,21 @@ CI installs must use:
 
 Lockfile changes must be committed intentionally and reviewed in PRs.
 
+### 4.2.1 Dependabot PR CI failures
+
+When a Dependabot PR causes CI job failures (e.g., `ci / quality`, `ci / build`, `ci / test`), treat it as a stop-the-line event. Do not merge with failing checks.
+
+**Remediation procedure:** Follow the **Temporary Exception Policy (Dependabot)** section in the Portfolio CI Triage runbook in the Documentation App:
+[`docs/50-operations/runbooks/rbk-portfolio-ci-triage.md`](https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-ci-triage)
+
+Key steps:
+- Identify root cause in GitHub Actions logs (e.g., `ERR_PNPM_BROKEN_LOCKFILE`, action incompatibility)
+- Roll back the failing action to its prior pinned SHA in `.github/workflows/ci.yml`
+- Add a temporary ignore rule in `.github/dependabot.yml` with an expiry date and tracking issue
+- Document the exception with exit criteria; do not leave open-ended ignores
+
+**Note:** The companion portfolio-docs repo owns the canonical exception policy and tracking. Cross-reference any exception opened in this repo with the portfolio-docs tracking issue.
+
 ### 4.3 Local quality contract (must stay valid)
 
 These commands must continue to work and be referenced in PR “Evidence”:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,7 @@ When a Dependabot PR causes CI job failures (e.g., `ci / quality`, `ci / build`,
 [`docs/50-operations/runbooks/rbk-portfolio-ci-triage.md`](https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-ci-triage)
 
 Key steps:
+
 - Identify root cause in GitHub Actions logs (e.g., `ERR_PNPM_BROKEN_LOCKFILE`, action incompatibility)
 - Roll back the failing action to its prior pinned SHA in `.github/workflows/ci.yml`
 - Add a temporary ignore rule in `.github/dependabot.yml` with an expiry date and tracking issue


### PR DESCRIPTION
## Summary


This pull request adds new documentation outlining the procedure to follow when a Dependabot pull request causes CI failures. It emphasizes the importance of not merging PRs with failing checks and provides a step-by-step remediation process, referencing the official runbook for handling such exceptions.

**Dependabot CI failure handling:**

* Added a new section to `.github/copilot-instructions.md` describing the process for addressing CI failures caused by Dependabot PRs, including investigation, rollback, temporary ignores, and documentation requirements. The section also references the canonical runbook and stresses the need for cross-repo tracking.

## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional):

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [x] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [x] `ci / quality` passed (lint, format, typecheck)
- [x] `ci / secrets-scan` passed (PR-only gate)
- [x] `ci / test` passed (unit + E2E tests)
- [x] `ci / link-validation` passed (registry + evidence links; Stage 3.5)
- [x] `ci / build` passed (depends on quality, test, link-validation)
- [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)
- Notes:
