### PR TITLE
docs: clarify link-validation scope (full E2E suite, not only evidence links)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Wait for server to be ready
         run: npx wait-on http://localhost:3000
 
-      - name: Link checks (Playwright)
+      - name: E2E suite (routes, evidence links, security, registry) via Playwright
         run: pnpm links:check
 
       - name: Upload Playwright report (on failure)

--- a/README.md
+++ b/README.md
@@ -92,19 +92,19 @@ See `.env.example` for the public-safe configuration contract.
 
 All variables prefixed with `NEXT_PUBLIC_` are exposed to the browser. Do not place secrets, tokens, private endpoints, or sensitive values in `NEXT_PUBLIC_*`.
 
-## Governance (Implemented)
+## Governance
 
 Phase 1–3 governance is enforced:
 
 - Required CI checks with stable names:
   - `ci / quality` (lint, format:check, typecheck)
-  - `ci / link-validation` (registry validation + evidence link checks; Stage 3.5)
+  - `ci / link-validation` (registry validation + full Playwright E2E suite: routes, evidence links, security headers, CSRF, rate-limiting)
   - `ci / build` (Next.js build; depends on quality and link-validation)
 - Deterministic installs in CI: `pnpm install --frozen-lockfile`
 - Supply chain and static analysis: CodeQL (JS/TS) and Dependabot (weekly; majors excluded)
 - Audit posture: CI blocks on high/critical advisories; low/medium are logged and require a ticket or risk register entry if they persist
 
-## Security (Stage 4.4)
+## Security
 
 - OWASP security headers and CSP configured in [next.config.ts](next.config.ts) (DENY framing, nosniff, strict referrer policy, restricted permissions, CSP with analytics exception)
 - CSP is enforced with per-request nonces (proxy) and applied to inline scripts

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -667,12 +667,16 @@ elif [ $BUILD_EXIT_CODE -eq 0 ]; then
           print_troubleshooting "  1. Review failures above (see playwright-report for details)
   2. Run tests in UI mode for debugging: pnpm playwright test --ui
   3. Run tests in debug mode: pnpm playwright test --debug
-  4. Link validation file: e2e/evidence-links.spec.ts (via links:check)
+  4. Test files (all three run via pnpm links:check → pnpm test:e2e):
+     - tests/e2e/evidence-links.spec.ts (evidence UI, badges, viewports, dark mode, a11y)
+     - tests/e2e/routes.spec.ts (route coverage, 404s, health/robots/sitemap, CSP, CSRF, rate-limit)
+     - tests/e2e/smoke.spec.ts (smoke renders + docs link presence)
   5. Tests verify:
-     - Routes render correctly
+     - All core routes render (/, /cv, /projects, /contact, /projects/[slug])
      - Evidence links resolve to docs and GitHub targets
      - Badges render correctly
      - Responsive layouts work (mobile/tablet/desktop)
+     - Security headers (CSP nonce), CSRF tokens, and rate-limiting behaviour
   6. View detailed HTML report: npx playwright show-report
   7. Common issues:
      - Missing or invalid env vars


### PR DESCRIPTION
## Summary

Wording-only corrections to align three locations where `ci / link-validation` was described as running only evidence link checks, when it actually runs the full Playwright E2E suite.

## What changed

| File | Old wording | New wording |
|---|---|---|
| `.github/workflows/ci.yml` | Step name: `Link checks (Playwright)` | `E2E suite (routes, evidence links, security, registry) via Playwright` |
| `README.md` | `registry validation + evidence link checks; Stage 3.5` | `registry validation + full Playwright E2E suite: routes, evidence links, security headers, CSRF, rate-limiting` |
| `scripts/verify-local.sh` | Troubleshooting text referenced only `e2e/evidence-links.spec.ts` | Lists all three spec files and their full scope |

## Rationale

`pnpm links:check` maps to `pnpm test:e2e`, which runs **all three** Playwright spec files:
- `evidence-links.spec.ts` — evidence UI, badges, viewports, dark mode, accessibility
- `routes.spec.ts` — route coverage, 404s, health/robots/sitemap, CSP nonces, CSRF tokens, rate-limiting
- `smoke.spec.ts` — smoke renders + docs link presence

The previous wording caused reviewer confusion about what the gate actually covers.

## Evidence

- No logic changes; wording only
- `pnpm verify:quick` passes locally
- `pnpm links:check` passes locally (66 tests, 35s)

## Security note

No secrets added. No functional changes.

## Documentation impact

None beyond these three files.