### PR TITLE
feat(ci): add non-blocking external evidence link monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Wait for server to be ready
         run: npx wait-on http://localhost:3000
 
-      - name: E2E suite (routes, evidence links, security, registry) via Playwright
+      - name: Link checks (Playwright)
         run: pnpm links:check
 
       - name: Upload Playwright report (on failure)

--- a/.github/workflows/external-link-monitor.yml
+++ b/.github/workflows/external-link-monitor.yml
@@ -1,0 +1,42 @@
+name: external-link-monitor
+
+on:
+  schedule:
+    - cron: "20 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NEXT_PUBLIC_DOCS_BASE_URL: https://bns-portfolio-docs.vercel.app
+  NEXT_PUBLIC_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-app
+  NEXT_PUBLIC_DOCS_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-docs
+  NEXT_PUBLIC_SITE_URL: https://bns-portfolio.vercel.app
+
+jobs:
+  check-external-evidence-links:
+    name: check-external-evidence-links
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+        with:
+          version: "10.0.0"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install deps (frozen)
+        run: pnpm install --frozen-lockfile
+
+      - name: Check external evidence links (live)
+        run: pnpm links:check:external

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Phase 1–3 governance is enforced:
   - `ci / quality` (lint, format:check, typecheck)
   - `ci / link-validation` (registry validation + full Playwright E2E suite: routes, evidence links, security headers, CSRF, rate-limiting)
   - `ci / build` (Next.js build; depends on quality and link-validation)
+- Live external-link monitor is intentionally separate from required PR checks:
+  - `external-link-monitor / check-external-evidence-links` (scheduled + on-demand live HTTP checks against evidence URLs)
+  - This avoids flaky PR failures caused by third-party uptime/rate-limits while still monitoring real connectivity.
 - Deterministic installs in CI: `pnpm install --frozen-lockfile`
 - Supply chain and static analysis: CodeQL (JS/TS) and Dependabot (weekly; majors excluded)
 - Audit posture: CI blocks on high/critical advisories; low/medium are logged and require a ticket or risk register entry if they persist
@@ -257,7 +260,8 @@ Secrets will still be scanned in CI (GitHub Actions), but setting up the local h
 ```bash
 pnpm registry:validate # Validate projects.yml schema and integrity
 pnpm registry:list     # List all projects with interpolated values
-pnpm links:check       # Run Playwright link validation (evidence URL smoke tests)
+pnpm links:check       # Run deterministic Playwright E2E validation (DOM presence + internal routes/APIs)
+pnpm links:check:external # Run live HTTP checks for external evidence links (best-effort monitor)
 ```
 
 **Comprehensive validation:**

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "registry:list": "tsx src/lib/registry.ts --list",
     "env:validate": "tsx scripts/env-validate.ts",
     "links:check": "pnpm test:e2e",
+    "links:check:external": "tsx scripts/external-links-monitor.ts",
     "analyze:bundle": "ANALYZE=true pnpm build",
     "analyze:build": "node -e \"const { execSync } = require('node:child_process'); const start = Date.now(); execSync('next build', { stdio: 'inherit' }); console.log('Build time (s):', ((Date.now() - start) / 1000).toFixed(2));\"",
     "verify": "./scripts/verify-local.sh",

--- a/scripts/external-links-monitor.ts
+++ b/scripts/external-links-monitor.ts
@@ -1,0 +1,193 @@
+import { docsUrl } from "@/lib/config";
+import { evidenceLinks, loadProjectRegistry, type Project } from "@/lib/registry";
+
+type LinkCheckResult = {
+  url: string;
+  ok: boolean;
+  status?: number;
+  method?: "HEAD" | "GET";
+  error?: string;
+};
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.EXTERNAL_LINK_TIMEOUT_MS ?? "12000");
+const DEFAULT_RETRIES = Number(process.env.EXTERNAL_LINK_RETRIES ?? "2");
+const USER_AGENT =
+  process.env.EXTERNAL_LINK_USER_AGENT ??
+  "portfolio-app-external-link-monitor/1.0 (+https://github.com/bryce-seefieldt/portfolio-app)";
+
+const FALLBACK_TO_GET_STATUSES = new Set([401, 403, 405]);
+const NON_FATAL_REACHABLE_STATUSES = new Set([401, 403]);
+
+function toAbsoluteUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function materializeEvidenceUrls(project: Project): string[] {
+  const urls = new Set<string>();
+
+  if (project.repoUrl) urls.add(project.repoUrl);
+  if (project.demoUrl) urls.add(project.demoUrl);
+  if (project.evidence?.github) urls.add(project.evidence.github);
+
+  const computed = evidenceLinks(project);
+  if (computed.dossier) urls.add(computed.dossier);
+  if (computed.threatModel) urls.add(computed.threatModel);
+  if (computed.adrs) urls.add(computed.adrs);
+  if (computed.runbooks) urls.add(computed.runbooks);
+
+  for (const adr of project.evidence?.adr ?? []) {
+    urls.add(adr.url.startsWith("http") ? adr.url : docsUrl(adr.url));
+  }
+
+  for (const runbook of project.evidence?.runbooks ?? []) {
+    urls.add(runbook.url.startsWith("http") ? runbook.url : docsUrl(runbook.url));
+  }
+
+  return Array.from(urls);
+}
+
+function collectExternalUrls(): { urls: string[]; skippedNonAbsolute: number } {
+  const projects = loadProjectRegistry();
+  const urls = new Set<string>();
+  let skippedNonAbsolute = 0;
+
+  for (const project of projects) {
+    for (const candidate of materializeEvidenceUrls(project)) {
+      const absolute = toAbsoluteUrl(candidate);
+      if (!absolute) {
+        skippedNonAbsolute += 1;
+        continue;
+      }
+      urls.add(absolute);
+    }
+  }
+
+  return {
+    urls: Array.from(urls).sort((a, b) => a.localeCompare(b)),
+    skippedNonAbsolute,
+  };
+}
+
+function isSuccessfulStatus(status: number): boolean {
+  return status < 400 || NON_FATAL_REACHABLE_STATUSES.has(status);
+}
+
+async function fetchWithMethod(url: string, method: "HEAD" | "GET"): Promise<Response> {
+  return fetch(url, {
+    method,
+    redirect: "follow",
+    headers: {
+      "user-agent": USER_AGENT,
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+}
+
+async function checkUrl(url: string): Promise<LinkCheckResult> {
+  for (let attempt = 1; attempt <= DEFAULT_RETRIES + 1; attempt += 1) {
+    try {
+      const headResponse = await fetchWithMethod(url, "HEAD");
+
+      if (isSuccessfulStatus(headResponse.status)) {
+        return { url, ok: true, status: headResponse.status, method: "HEAD" };
+      }
+
+      if (FALLBACK_TO_GET_STATUSES.has(headResponse.status)) {
+        const getResponse = await fetchWithMethod(url, "GET");
+        if (isSuccessfulStatus(getResponse.status)) {
+          return { url, ok: true, status: getResponse.status, method: "GET" };
+        }
+
+        if (attempt > DEFAULT_RETRIES || getResponse.status < 500) {
+          return {
+            url,
+            ok: false,
+            status: getResponse.status,
+            method: "GET",
+            error: `HTTP ${getResponse.status}`,
+          };
+        }
+      } else if (attempt > DEFAULT_RETRIES || headResponse.status < 500) {
+        return {
+          url,
+          ok: false,
+          status: headResponse.status,
+          method: "HEAD",
+          error: `HTTP ${headResponse.status}`,
+        };
+      }
+    } catch (error) {
+      if (attempt > DEFAULT_RETRIES) {
+        return {
+          url,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+  }
+
+  return { url, ok: false, error: "Unknown error" };
+}
+
+async function run(): Promise<number> {
+  const { urls, skippedNonAbsolute } = collectExternalUrls();
+
+  if (urls.length === 0) {
+    console.log("No external URLs found in registry evidence data. Nothing to check.");
+    return 0;
+  }
+
+  console.log(`Checking ${urls.length} external links from project registry evidence...`);
+  if (skippedNonAbsolute > 0) {
+    console.log(
+      `Skipped ${skippedNonAbsolute} non-absolute URLs (expected locally when DOCS_BASE_URL is relative).`,
+    );
+  }
+  const results: LinkCheckResult[] = [];
+
+  for (const url of urls) {
+    const result = await checkUrl(url);
+    results.push(result);
+
+    if (result.ok) {
+      const via = result.method ? ` via ${result.method}` : "";
+      const status = result.status ? ` (${result.status})` : "";
+      console.log(`OK${status}${via}: ${url}`);
+    } else {
+      const detail = result.error ?? (result.status ? `HTTP ${result.status}` : "unknown failure");
+      console.error(`FAIL: ${url} -> ${detail}`);
+    }
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  const passed = results.length - failed.length;
+
+  console.log("\nExternal link monitor summary");
+  console.log(`Passed: ${passed}`);
+  console.log(`Failed: ${failed.length}`);
+
+  if (failed.length > 0) {
+    console.error("\nFailed URLs:");
+    for (const failure of failed) {
+      const detail = failure.error ?? (failure.status ? `HTTP ${failure.status}` : "unknown failure");
+      console.error(`- ${failure.url} (${detail})`);
+    }
+    return 1;
+  }
+
+  return 0;
+}
+
+void run().then((code) => {
+  process.exit(code);
+});

--- a/scripts/external-links-monitor.ts
+++ b/scripts/external-links-monitor.ts
@@ -179,7 +179,8 @@ async function run(): Promise<number> {
   if (failed.length > 0) {
     console.error("\nFailed URLs:");
     for (const failure of failed) {
-      const detail = failure.error ?? (failure.status ? `HTTP ${failure.status}` : "unknown failure");
+      const detail =
+        failure.error ?? (failure.status ? `HTTP ${failure.status}` : "unknown failure");
       console.error(`- ${failure.url} (${detail})`);
     }
     return 1;


### PR DESCRIPTION
## Summary

Adds a live external evidence-link monitor following best-practice separation between deterministic PR gates and third-party connectivity checks.

## What changed

- Added 
  - Enumerates external evidence URLs from the registry
  - Uses  checks with  fallback for common -blocked responses
  - Includes retry/timeout behavior and clear pass/fail summary output
  - Treats common auth-protected responses () as reachable
- Added workflow 
  - Runs on schedule and 
  - Executes 
> portfolio-app@1.0.0 links:check:external /home/seven30/src/portfolio/portfolio-app
> tsx scripts/external-links-monitor.ts

[dotenv@17.3.1] injecting env (6) from .env.local -- tip: 🛡️ auth for agents: https://vestauth.com
Checking 3 external links from project registry evidence...
Skipped 13 non-absolute URLs (expected locally when DOCS_BASE_URL is relative).
OK (200) via HEAD: https://bns-portfolio-docs.vercel.app/
OK (200) via HEAD: https://github.com/bryce-seefieldt/portfolio-app
OK (200) via HEAD: https://github.com/bryce-seefieldt/portfolio-docs

External link monitor summary
Passed: 3
Failed: 0
- Added package script:
  - 
- Updated README policy language:
  - Clarifies required PR checks remain deterministic
  - Documents external live monitoring as separate, non-blocking observability

## Why this approach

- Keeps PR CI stable and deterministic
- Still provides live signal when docs/GitHub evidence links break due to real-world connectivity issues

## Validation

- 
> portfolio-app@1.0.0 lint /home/seven30/src/portfolio/portfolio-app
> eslint . --max-warnings=0 "scripts/external-links-monitor.ts"
- 
> portfolio-app@1.0.0 typecheck /home/seven30/src/portfolio/portfolio-app
> tsc --noEmit
- 
> portfolio-app@1.0.0 links:check:external /home/seven30/src/portfolio/portfolio-app
> tsx scripts/external-links-monitor.ts

[dotenv@17.3.1] injecting env (6) from .env.local -- tip: 🔐 prevent committing .env to code: https://dotenvx.com/precommit
Checking 3 external links from project registry evidence...
Skipped 13 non-absolute URLs (expected locally when DOCS_BASE_URL is relative).
OK (200) via HEAD: https://bns-portfolio-docs.vercel.app/
OK (200) via HEAD: https://github.com/bryce-seefieldt/portfolio-app
OK (200) via HEAD: https://github.com/bryce-seefieldt/portfolio-docs

External link monitor summary
Passed: 3
Failed: 0 (passes locally)

## Security / Risk

- No secrets added
- No production runtime behavior changes
- CI scope only