### PR TITLE
feat: add /docs reverse-proxy rewrite and update canonical URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ NEXT_PUBLIC_SITE_URL=
 # If not set, the app will default to "/docs" (works only if docs truly live there).
 NEXT_PUBLIC_DOCS_BASE_URL=
 
+# Docs upstream origin URL (server-side only — NOT exposed to browser).
+# Required for the /docs reverse-proxy rewrite in next.config.ts.
+# Set to the Vercel origin of the portfolio-docs project.
+# Example: https://bns-portfolio-docs.vercel.app
+DOCS_UPSTREAM_URL=
+
 # Docs GitHub repository URL (for deep links to source of docs)
 # Example: https://github.com/your-handle/portfolio-docs
 NEXT_PUBLIC_DOCS_GITHUB_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ concurrency:
 
 # Public, non-secret env needed for registry interpolation during CI builds
 env:
-  NEXT_PUBLIC_DOCS_BASE_URL: https://bns-portfolio-docs.vercel.app
+  NEXT_PUBLIC_DOCS_BASE_URL: https://bryce.seefieldt.ca/docs
   NEXT_PUBLIC_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-app
   NEXT_PUBLIC_DOCS_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-docs
-  NEXT_PUBLIC_SITE_URL: https://bns-portfolio.vercel.app
+  NEXT_PUBLIC_SITE_URL: https://bryce.seefieldt.ca
 
 jobs:
   quality:

--- a/.github/workflows/external-link-monitor.yml
+++ b/.github/workflows/external-link-monitor.yml
@@ -9,10 +9,10 @@ permissions:
   contents: read
 
 env:
-  NEXT_PUBLIC_DOCS_BASE_URL: https://bns-portfolio-docs.vercel.app
+  NEXT_PUBLIC_DOCS_BASE_URL: https://bryce.seefieldt.ca/docs
   NEXT_PUBLIC_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-app
   NEXT_PUBLIC_DOCS_GITHUB_URL: https://github.com/bryce-seefieldt/portfolio-docs
-  NEXT_PUBLIC_SITE_URL: https://bns-portfolio.vercel.app
+  NEXT_PUBLIC_SITE_URL: https://bryce.seefieldt.ca
 
 jobs:
   check-external-evidence-links:

--- a/next.config.ts
+++ b/next.config.ts
@@ -66,6 +66,20 @@ const nextConfig: NextConfig = {
   // - Environment variables used: VERCEL_ENV, VERCEL_GIT_COMMIT_SHA, BUILD_TIME
   // See: `docs/60-projects/portfolio-app/08-observability.md`
 
+  // Routing: Proxy /docs/* to the separate Docusaurus docs site origin.
+  // This lets bryce.seefieldt.ca/docs serve the docs project transparently.
+  // Set DOCS_UPSTREAM_URL in Vercel env to the docs project origin
+  // (e.g. https://bns-portfolio-docs.vercel.app).
+  // When not set (local dev without docs), rewrites are skipped gracefully.
+  rewrites: async () => {
+    const docsUpstream = process.env.DOCS_UPSTREAM_URL;
+    if (!docsUpstream) return [];
+    return [
+      { source: "/docs", destination: `${docsUpstream}/docs` },
+      { source: "/docs/:path*", destination: `${docsUpstream}/docs/:path*` },
+    ];
+  },
+
   // Caching: Configure HTTP Cache-Control headers
   headers: async () => [
     {


### PR DESCRIPTION
## Summary

Adds Next.js rewrites to proxy /docs/* to the docs Vercel origin, and updates all hardcoded bns-portfolio URLs to the canonical bryce.seefieldt.ca domain.

## Changes

- next.config.ts: added rewrites() proxying /docs and /docs/:path* to DOCS_UPSTREAM_URL (skipped gracefully when env var not set)
- .env.example: added DOCS_UPSTREAM_URL (server-side only, not NEXT_PUBLIC_)
- .github/workflows/ci.yml: NEXT_PUBLIC_SITE_URL and NEXT_PUBLIC_DOCS_BASE_URL updated to canonical domain
- .github/workflows/external-link-monitor.yml: same URL updates

## Required Vercel env var

DOCS_UPSTREAM_URL=https://bns-portfolio-docs.vercel.app (set in Production + Preview)

## Merge order

Merge the companion portfolio-docs PR (feat/domain-migration-docs-routing, PR #110) first, then merge this one.