### PR TITLE
feat: canonicalize production URLs to bryce.seefieldt.ca

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ NEXT_PUBLIC_DOCS_BASE_URL=
 # Docs upstream origin URL (server-side only — NOT exposed to browser).
 # Required for the /docs reverse-proxy rewrite in next.config.ts.
 # Set to the Vercel origin of the portfolio-docs project.
-# Example: https://bns-portfolio-docs.vercel.app
+# Example: https://bryce.seefieldt.ca/docs (production) or https://bns-portfolio-docs.vercel.app (preview)
 DOCS_UPSTREAM_URL=
 
 # Docs GitHub repository URL (for deep links to source of docs)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,7 +69,7 @@ Before proposing changes, review and internalize the existing architecture and c
 - Use the import alias `@/*` for internal imports (configured in `tsconfig.json`).
 - Keep route pages simple and reviewer-focused. Deep technical details belong in the Documentation App.
 - Prefer small, composable components under `src/components/`.
-- Follow the code commentary standard: https://bns-portfolio-docs.vercel.app/docs/engineering/commentary-standard (examples: https://bns-portfolio-docs.vercel.app/docs/reference/commentary-examples).
+- Follow the code commentary standard: https://bryce.seefieldt.ca/docs/engineering/commentary-standard (examples: https://bryce.seefieldt.ca/docs/reference/commentary-examples).
 
 **Phase status:** Phases 1-7 are complete. Current work focuses on incremental hardening, content quality, and evidence freshness while preserving established CI and governance contracts.
 
@@ -143,7 +143,7 @@ Lockfile changes must be committed intentionally and reviewed in PRs.
 When a Dependabot PR causes CI job failures (e.g., `ci / quality`, `ci / build`, `ci / test`), treat it as a stop-the-line event. Do not merge with failing checks.
 
 **Remediation procedure:** Follow the **Temporary Exception Policy (Dependabot)** section in the Portfolio CI Triage runbook in the Documentation App:
-[`docs/50-operations/runbooks/rbk-portfolio-ci-triage.md`](https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-ci-triage)
+[`docs/50-operations/runbooks/rbk-portfolio-ci-triage.md`](https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-ci-triage)
 
 Key steps:
 
@@ -311,7 +311,7 @@ When phase work spans both repositories:
 4. Reference docs issue in docs PRs (`Closes #Y`)
 5. Verify both PRs merged before marking phase stage complete
 
-**Reference:** See [Template Usage Guide](https://bns-portfolio-docs.vercel.app/docs/_meta/templates) for full details on all templates.
+**Reference:** See [Template Usage Guide](https://bryce.seefieldt.ca/docs/_meta/templates) for full details on all templates.
 
 ---
 
@@ -366,7 +366,7 @@ Use `NEXT_PUBLIC_DOCS_BASE_URL` to construct links to published docs.
 
 **Examples:**
 
-- ✅ `NEXT_PUBLIC_DOCS_BASE_URL + "docs/portfolio/roadmap"` → `https://bns-portfolio-docs.vercel.app/docs/portfolio/roadmap`
+- ✅ `NEXT_PUBLIC_DOCS_BASE_URL + "docs/portfolio/roadmap"` → `https://bryce.seefieldt.ca/docs/portfolio/roadmap`
 - ✅ `docsUrl("portfolio/architecture")` (use the helper function)
 - ❌ `NEXT_PUBLIC_DOCS_BASE_URL + "docs/00-portfolio/roadmap.md"` (wrong prefix + extension)
 - ❌ `NEXT_PUBLIC_DOCS_BASE_URL + "portfolio.roadmap"` (wrong separator)
@@ -415,10 +415,10 @@ Ensure these `NEXT_PUBLIC_*` variables are defined (checked in CI):
 
 ```typescript
 // .env.example
-NEXT_PUBLIC_DOCS_BASE_URL=https://bns-portfolio-docs.vercel.app/docs/
+NEXT_PUBLIC_DOCS_BASE_URL=https://bryce.seefieldt.ca/docs
 NEXT_PUBLIC_DOCS_GITHUB_URL=https://github.com/bryce-seefieldt/portfolio-docs/
 NEXT_PUBLIC_GITHUB_URL=https://github.com/bryce-seefieldt/portfolio-app
-NEXT_PUBLIC_SITE_URL=https://bns-portfolio.vercel.app/
+NEXT_PUBLIC_SITE_URL=https://bryce.seefieldt.ca/
 ```
 
 ### 6.5 Documentation updates expectation
@@ -1125,10 +1125,10 @@ Do NOT add tests for:
 
 ### 9.9 Test Reference Documentation
 
-- **Comprehensive Testing Guide:** [docs/70-reference/testing-guide.md](https://bns-portfolio-docs.vercel.app/docs/reference/testing-guide)
+- **Comprehensive Testing Guide:** [docs/70-reference/testing-guide.md](https://bryce.seefieldt.ca/docs/reference/testing-guide)
 - **Vitest Documentation:** https://vitest.dev
 - **Playwright Documentation:** https://playwright.dev
-- **Implementation Issue:** [stage-3-3-app-issue.md](https://bns-portfolio-docs.vercel.app/docs/portfolio/roadmap/issues/stage-3-3-app-issue)
+- **Implementation Issue:** [stage-3-3-app-issue.md](https://bryce.seefieldt.ca/docs/portfolio/roadmap/issues/stage-3-3-app-issue)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ The Portfolio App uses a **staging-first deployment workflow** to ensure changes
 | ----------- | ----------- | ------------------------------------------ | ----------------------------------------- |
 | Preview     | PR branches | Auto-generated (`*.vercel.app`)            | PR review and feature validation          |
 | Staging     | `staging`   | `https://staging-bns-portfolio.vercel.app` | Pre-production validation and smoke tests |
-| Production  | `main`      | `https://bryce.seefieldt.ca`         | Live public site                          |
+| Production  | `main`      | `https://bryce.seefieldt.ca`               | Live public site                          |
 
 ### Local Development → Staging → Production Workflow
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The design goal is for reviewers to evaluate the portfolio like a real service: 
 
 ## Reviewer quickstart
 
-- Reviewer guide: https://bns-portfolio-docs.vercel.app/docs/portfolio/reviewer-guide
-- Portfolio App dossier: https://bns-portfolio-docs.vercel.app/docs/projects/portfolio-app/
+- Reviewer guide: https://bryce.seefieldt.ca/docs/portfolio/reviewer-guide
+- Portfolio App dossier: https://bryce.seefieldt.ca/docs/projects/portfolio-app/
 
 ## Documentation App (Evidence Engine)
 
@@ -29,7 +29,7 @@ Enterprise-grade documentation is hosted separately to preserve a clean product 
 
 - Docs base URL is configured via: `NEXT_PUBLIC_DOCS_BASE_URL`
 - The code constructs evidence links through: `src/lib/config.ts`
-- Code commentary standard: https://bns-portfolio-docs.vercel.app/docs/engineering/commentary-standard (examples: https://bns-portfolio-docs.vercel.app/docs/reference/commentary-examples)
+- Code commentary standard: https://bryce.seefieldt.ca/docs/engineering/commentary-standard (examples: https://bryce.seefieldt.ca/docs/reference/commentary-examples)
 
 ## Tech stack
 
@@ -113,8 +113,8 @@ Phase 1–3 governance is enforced:
 - CSP is enforced with per-request nonces (proxy) and applied to inline scripts
 - Mutation endpoints require Zod validation, CSRF checks, and rate limiting
 - Public-safe environment contract documented in [.env.example](.env.example); all `NEXT_PUBLIC_*` values are client-visible
-- Threat model and security posture documented in [docs/60-projects/portfolio-app/04-security.md](https://bns-portfolio-docs.vercel.app/docs/60-projects/portfolio-app/04-security.md) and [docs/40-security/threat-models/portfolio-app-threat-model-v2.md](https://bns-portfolio-docs.vercel.app/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)
-- Dependency vulnerability response handled via [docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md](https://bns-portfolio-docs.vercel.app/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md); secrets incidents via [docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md](https://bns-portfolio-docs.vercel.app/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)
+- Threat model and security posture documented in [docs/60-projects/portfolio-app/04-security.md](https://bryce.seefieldt.ca/docs/60-projects/portfolio-app/04-security.md) and [docs/40-security/threat-models/portfolio-app-threat-model-v2.md](https://bryce.seefieldt.ca/docs/40-security/threat-models/portfolio-app-threat-model-v2.md)
+- Dependency vulnerability response handled via [docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md](https://bryce.seefieldt.ca/docs/50-operations/runbooks/rbk-portfolio-dependency-vulnerability.md); secrets incidents via [docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md](https://bryce.seefieldt.ca/docs/50-operations/runbooks/rbk-portfolio-secrets-incident.md)
 
 ### Local quality contract
 
@@ -323,7 +323,7 @@ The Portfolio App uses a **staging-first deployment workflow** to ensure changes
 | ----------- | ----------- | ------------------------------------------ | ----------------------------------------- |
 | Preview     | PR branches | Auto-generated (`*.vercel.app`)            | PR review and feature validation          |
 | Staging     | `staging`   | `https://staging-bns-portfolio.vercel.app` | Pre-production validation and smoke tests |
-| Production  | `main`      | `https://bns-portfolio.vercel.app`         | Live public site                          |
+| Production  | `main`      | `https://bryce.seefieldt.ca`         | Live public site                          |
 
 ### Local Development → Staging → Production Workflow
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -69,7 +69,7 @@ const nextConfig: NextConfig = {
   // Routing: Proxy /docs/* to the separate Docusaurus docs site origin.
   // This lets bryce.seefieldt.ca/docs serve the docs project transparently.
   // Set DOCS_UPSTREAM_URL in Vercel env to the docs project origin
-  // (e.g. https://bns-portfolio-docs.vercel.app).
+  // (e.g. https://bryce.seefieldt.ca/docs or https://bns-portfolio-docs.vercel.app for preview).
   // When not set (local dev without docs), rewrites are skipped gracefully.
   rewrites: async () => {
     const docsUpstream = process.env.DOCS_UPSTREAM_URL;

--- a/scripts/verify-local.sh
+++ b/scripts/verify-local.sh
@@ -521,7 +521,7 @@ if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$SKIP_PERFORMANCE" = false ]; then
   4. Consider code splitting or lazy loading for large components
   
   For detailed guidance, see:
-  https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#bundle-size-regression"
+  https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#bundle-size-regression"
       elif (( $(echo "$BUNDLE_SIZE_MB > $BUNDLE_SIZE_WARNING_THRESHOLD" | bc -l) )); then
         print_warning "Bundle size (${BUNDLE_SIZE_MB} MB) exceeds warning threshold (${BUNDLE_SIZE_WARNING_THRESHOLD} MB)"
         print_info "Growth: +$(echo "scale=1; (($BUNDLE_SIZE_MB - $BASELINE_BUNDLE_MB) / $BASELINE_BUNDLE_MB) * 100" | bc)%"
@@ -533,7 +533,7 @@ if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$SKIP_PERFORMANCE" = false ]; then
   3. Check if tree-shaking is working correctly
   
   Documentation:
-  https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#bundle-size-regression"
+  https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#bundle-size-regression"
       elif (( $(echo "$BUNDLE_SIZE_MB > $BASELINE_BUNDLE_MB" | bc -l) )); then
         print_success "Bundle size (${BUNDLE_SIZE_MB} MB) within acceptable range (+$(echo "scale=1; $BUNDLE_SIZE_MB - $BASELINE_BUNDLE_MB" | bc) MB)"
       else
@@ -591,7 +591,7 @@ if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$SKIP_PERFORMANCE" = false ]; then
   Expected header: ${BASELINE_CACHE_CONTROL}
   
   Documentation:
-  https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#cache-headers-missing"
+  https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#cache-headers-missing"
     elif echo "$CACHE_CONTROL_HEADER" | grep -q "$BASELINE_CACHE_CONTROL"; then
       print_success "Cache-Control header correct: $CACHE_CONTROL_HEADER"
     else
@@ -606,7 +606,7 @@ if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$SKIP_PERFORMANCE" = false ]; then
   3. Update baseline if new caching strategy is intended
   
   Documentation:
-  https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#cache-headers-mismatch"
+  https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#cache-headers-mismatch"
     fi
   fi
 fi
@@ -1007,27 +1007,27 @@ if [ $BUILD_EXIT_CODE -eq 0 ] && [ "$SKIP_PERFORMANCE" = false ]; then
   echo "─────────────────────────────────────────────────────────────────"
   echo ""
   echo "  Performance Troubleshooting Guide:"
-  echo -e "  ${BLUE}https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting${NC}"
+  echo -e "  ${BLUE}https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting${NC}"
   echo ""
   echo "  Specific Issues:"
   echo "  • Bundle Size Regression:"
-  echo -e "    ${BLUE}https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#bundle-size-regression${NC}"
+  echo -e "    ${BLUE}https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#bundle-size-regression${NC}"
   echo "  • Build Time Issues:"
-  echo -e "    ${BLUE}https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#slow-build-time${NC}"
+  echo -e "    ${BLUE}https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#slow-build-time${NC}"
   echo "  • Cache Headers:"
-  echo -e "    ${BLUE}https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#cache-headers-missing${NC}"
+  echo -e "    ${BLUE}https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-troubleshooting#cache-headers-missing${NC}"
   echo ""
 fi
 
 echo ""
 echo -e "${BLUE}${BOLD}Documentation & References:${NC}"
 echo "  - README: ./README.md"
-echo "  - Testing guide: https://bns-portfolio-docs.vercel.app/docs/reference/testing-guide"
-echo "  - Registry schema: https://bns-portfolio-docs.vercel.app/docs/reference/registry-schema-guide"
-echo "  - ADR-0011 (registry): https://bns-portfolio-docs.vercel.app/docs/architecture/adr/adr-0011-data-driven-project-registry"
+echo "  - Testing guide: https://bryce.seefieldt.ca/docs/reference/testing-guide"
+echo "  - Registry schema: https://bryce.seefieldt.ca/docs/reference/registry-schema-guide"
+echo "  - ADR-0011 (registry): https://bryce.seefieldt.ca/docs/architecture/adr/adr-0011-data-driven-project-registry"
 echo "  - Performance baseline (YAML): ./docs/performance-baseline.yml"
 echo "  - Performance baseline (docs): ./docs/performance-baseline.md"
-echo "  - Performance optimization: https://bns-portfolio-docs.vercel.app/docs/operations/runbooks/rbk-portfolio-performance-optimization"
+echo "  - Performance optimization: https://bryce.seefieldt.ca/docs/operations/runbooks/rbk-portfolio-performance-optimization"
 echo ""
 
 # Exit with failure code if any checks failed


### PR DESCRIPTION
- Replace all hardcoded bns-portfolio-docs.vercel.app and bns-portfolio.vercel.app production references with canonical domain
- Update DOCS_UPSTREAM_URL example to show both production (bryce.seefieldt.ca) and preview (bns-portfolio-docs.vercel.app) endpoints
- Update .env.local and .env.prod to use canonical domain for DOCS_BASE_URL and SITE_URL
- Update next.config.ts comment to clarify production vs preview endpoints
- Replace 8 doc links in README.md with canonical domain
- Update 12 URL references in verify-local.sh runbooks and troubleshooting output
- Update 6 instances in copilot-instructions.md including env examples
- Enforce policy: bns-portfolio.vercel.app used ONLY for preview/development

Closes Phase 2 domain migration cleanup

## Summary
This pull request updates all documentation, reference, and environment URLs throughout the codebase and documentation to use the new production domain (`https://bryce.seefieldt.ca`) instead of the previous Vercel preview domain. This ensures all links, configuration examples, and references consistently point to the correct live site and documentation locations.

The most important changes are:

**Documentation and Reference URL Updates:**
* All documentation links in `.github/copilot-instructions.md`, `README.md`, and `scripts/verify-local.sh` now point to `https://bryce.seefieldt.ca/docs` instead of the old Vercel domain. This affects reviewer guides, commentary standards, testing guides, runbooks, and other reference materials. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L72-R72) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L146-R146) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L314-R314) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L369-R369) [[5]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L418-R421) [[6]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L1128-R1131) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R32) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-R117) [[9]](diffhunk://#diff-103c4fd125d30f22c382141ea47c48dd43d33d26d1c452fc9b9794801df5c5d8L524-R524) [[10]](diffhunk://#diff-103c4fd125d30f22c382141ea47c48dd43d33d26d1c452fc9b9794801df5c5d8L536-R536) [[11]](diffhunk://#diff-103c4fd125d30f22c382141ea47c48dd43d33d26d1c452fc9b9794801df5c5d8L594-R594) [[12]](diffhunk://#diff-103c4fd125d30f22c382141ea47c48dd43d33d26d1c452fc9b9794801df5c5d8L609-R609) [[13]](diffhunk://#diff-103c4fd125d30f22c382141ea47c48dd43d33d26d1c452fc9b9794801df5c5d8L1010-R1030)

**Environment and Configuration Example Updates:**
* The `.env.example` file and code comments in `next.config.ts` have been updated to use the new docs and site URLs as examples, clarifying the distinction between production and preview environments. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL27-R27) [[2]](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL72-R72)

**Production Site URL Update:**
* The production deployment URL in the `README.md` has been updated from the Vercel preview domain to the new canonical production domain (`https://bryce.seefieldt.ca`).