### PR TITLE
fix: move /docs proxy rewrite to vercel.json to stop infinite loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,11 +21,10 @@ NEXT_PUBLIC_SITE_URL=
 # If not set, the app will default to "/docs" (works only if docs truly live there).
 NEXT_PUBLIC_DOCS_BASE_URL=
 
-# Docs upstream origin URL (server-side only — NOT exposed to browser).
-# Required for the /docs reverse-proxy rewrite in next.config.ts.
-# Set to the Vercel origin of the portfolio-docs project.
-# Example: https://bryce.seefieldt.ca/docs (production) or https://bns-portfolio-docs.vercel.app (preview)
-DOCS_UPSTREAM_URL=
+# NOTE: DOCS_UPSTREAM_URL is no longer used for routing.
+# The /docs proxy rewrite is now handled in vercel.json (Vercel edge layer).
+# This variable is kept here for reference only and should not be set in Vercel env vars.
+# DOCS_UPSTREAM_URL=
 
 # Docs GitHub repository URL (for deep links to source of docs)
 # Example: https://github.com/your-handle/portfolio-docs

--- a/next.config.ts
+++ b/next.config.ts
@@ -66,19 +66,9 @@ const nextConfig: NextConfig = {
   // - Environment variables used: VERCEL_ENV, VERCEL_GIT_COMMIT_SHA, BUILD_TIME
   // See: `docs/60-projects/portfolio-app/08-observability.md`
 
-  // Routing: Proxy /docs/* to the separate Docusaurus docs site origin.
-  // This lets bryce.seefieldt.ca/docs serve the docs project transparently.
-  // Set DOCS_UPSTREAM_URL in Vercel env to the docs project origin
-  // (e.g. https://bryce.seefieldt.ca/docs or https://bns-portfolio-docs.vercel.app for preview).
-  // When not set (local dev without docs), rewrites are skipped gracefully.
-  rewrites: async () => {
-    const docsUpstream = process.env.DOCS_UPSTREAM_URL;
-    if (!docsUpstream) return [];
-    return [
-      { source: "/docs", destination: `${docsUpstream}/docs` },
-      { source: "/docs/:path*", destination: `${docsUpstream}/docs/:path*` },
-    ];
-  },
+  // Routing: /docs/* is proxied to the Docusaurus docs site via vercel.json rewrites.
+  // This is handled at the Vercel edge layer (not Next.js) to avoid build-time env var
+  // dependencies and Vercel loop detection issues. See vercel.json for the rewrite config.
 
   // Caching: Configure HTTP Cache-Control headers
   headers: async () => [

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/docs",
+      "destination": "https://bns-portfolio-docs.vercel.app/docs"
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://bns-portfolio-docs.vercel.app/docs/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
The Next.js rewrites() in next.config.ts read DOCS_UPSTREAM_URL at build time. If that env var pointed to bryce.seefieldt.ca (the app's own domain), Vercel's edge detected a circular hop and returned INFINITE_LOOP_DETECTED (508).

Fix:
- Add vercel.json with hardcoded rewrites to bns-portfolio-docs.vercel.app
- Remove the env-var-driven rewrites() block from next.config.ts
- Vercel edge routing handles /docs/* before Next.js sees the request
- No env var dependency, no build-time configuration, no loop risk

Also: deprecate DOCS_UPSTREAM_URL in .env.example (no longer used)

## Summary
This pull request updates how routing for the `/docs` path is handled in the application. The proxy rewrite logic for `/docs` is moved from the Next.js configuration to the Vercel edge layer using `vercel.json`. This change simplifies environment variable management and avoids issues related to build-time dependencies and Vercel's loop detection.

Routing changes:

* Added a `vercel.json` file with rewrite rules to proxy `/docs` and `/docs/:path*` to the Docusaurus docs site at `https://bns-portfolio-docs.vercel.app/docs`.
* Removed the `/docs` proxy rewrite logic from `next.config.ts`, which previously depended on the `DOCS_UPSTREAM_URL` environment variable. Routing is now handled entirely at the Vercel edge.

Environment variable updates:

* Updated `.env.example` to clarify that `DOCS_UPSTREAM_URL` is no longer used for routing and should not be set in Vercel environment variables. The variable is kept for reference only.