### PR TITLE
docs: update copilot-instructions and README for vercel.json routing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,10 @@ Before proposing changes, review and internalize the existing architecture and c
   - global layout + navigation
 - `src/app/page.tsx`
   - evidence-first landing page
+- `vercel.json`
+  - Vercel edge-layer routing: rewrites `/docs` and `/docs/:path*` to the portfolio-docs origin (`bns-portfolio-docs.vercel.app`)
+  - Evaluated at Vercel's edge before Next.js sees the request; takes precedence over Next.js routing for matching paths
+  - **Do not add `/docs` rewrites in `next.config.ts`**: build-time env var dependencies caused an `INFINITE_LOOP_DETECTED` (508) production incident — routing belongs here, not in `rewrites()` in `next.config.ts`
 
 ### 2.2 Conventions
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The design goal is for reviewers to evaluate the portfolio like a real service: 
 Enterprise-grade documentation is hosted separately to preserve a clean product surface and maintain governance discipline.
 
 - Docs base URL is configured via: `NEXT_PUBLIC_DOCS_BASE_URL`
+- The `/docs/*` path is proxied to the portfolio-docs origin via Vercel edge rewrites in `vercel.json` (no env var required for routing)
 - The code constructs evidence links through: `src/lib/config.ts`
 - Code commentary standard: https://bryce.seefieldt.ca/docs/engineering/commentary-standard (examples: https://bryce.seefieldt.ca/docs/reference/commentary-examples)
 
@@ -42,6 +43,7 @@ Enterprise-grade documentation is hosted separately to preserve a clean product 
   - `src/lib/registry.ts` (YAML-backed registry loader with Zod validation and env interpolation)
   - `src/data/projects.yml` (canonical project registry data)
   - `src/data/projects.ts` (typed export of the validated registry)
+- `vercel.json` — Vercel edge-layer rewrites: proxies `/docs` and `/docs/:path*` to `bns-portfolio-docs.vercel.app`
 
 ## Data-driven project registry (Stage 3.1)
 


### PR DESCRIPTION
- Add vercel.json to key app files in section 2.1 with routing rationale and warning not to re-add rewrites() to next.config.ts
- Note /docs proxy via Vercel edge rewrites in Documentation App section
- Add vercel.json to tech stack in README

## Summary
This pull request updates documentation to clarify how documentation routing is handled in the project, specifically emphasizing the use of Vercel edge-layer rewrites for the `/docs` path instead of Next.js configuration. The changes help prevent routing issues and production incidents by documenting the correct approach and rationale.

Documentation and routing clarification:

* Updated `.github/copilot-instructions.md` to document that `vercel.json` handles edge-layer routing for `/docs` and `/docs/:path*`, explicitly warning against adding `/docs` rewrites in `next.config.ts` due to a prior infinite loop production incident.
* Updated `README.md` to note that `/docs/*` is proxied via Vercel edge rewrites in `vercel.json` and does not require environment variables for routing.
* Added `vercel.json` to the list of core files in `README.md`, describing its role in proxying `/docs` routes to the documentation origin.