### PR TITLE
fix: canonicalize Evidence Docs link to production /docs path

### DIFF
--- a/src/lib/__tests__/config-variants.test.ts
+++ b/src/lib/__tests__/config-variants.test.ts
@@ -86,4 +86,14 @@ describe("config variants", () => {
     expect(config.isStaging()).toBe(false);
     expect(config.isDevelopment()).toBe(false);
   });
+
+  it("should canonicalize preview docs origin in production", async () => {
+    process.env.VERCEL_ENV = "production";
+    process.env.NEXT_PUBLIC_SITE_URL = "https://bryce.seefieldt.ca";
+    process.env.NEXT_PUBLIC_DOCS_BASE_URL = "https://bns-portfolio-docs.vercel.app";
+    vi.resetModules();
+
+    const config = await import("../config");
+    expect(config.DOCS_BASE_URL).toBe("https://bryce.seefieldt.ca/docs");
+  });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -67,7 +67,20 @@ function normalizeDocsBaseUrl(value?: string): string {
   if (!trimmed) return "/docs";
 
   const absolute = asAbsoluteUrl(trimmed);
-  if (absolute) return normalizeBaseUrl(absolute);
+  if (absolute) {
+    const docsHost = new URL(absolute).hostname.toLowerCase();
+    const siteHost = SITE_URL ? new URL(SITE_URL).hostname.toLowerCase() : null;
+
+    // Safety rail: never expose the preview docs origin on the production app domain.
+    if (
+      docsHost === "bns-portfolio-docs.vercel.app" &&
+      (env.VERCEL_ENV === "production" || siteHost === "bryce.seefieldt.ca")
+    ) {
+      return "https://bryce.seefieldt.ca/docs";
+    }
+
+    return normalizeBaseUrl(absolute);
+  }
 
   if (trimmed.startsWith("/")) {
     return normalizeBaseUrl(trimmed);


### PR DESCRIPTION
- Add production guardrail in config to prevent preview docs origin from being exposed in the header nav link
- Canonicalize bns-portfolio-docs.vercel.app to bryce.seefieldt.ca/docs in production contexts
- Add regression test for canonicalization behavior

## Summary
This pull request introduces a safety mechanism to prevent exposing the preview documentation origin (`bns-portfolio-docs.vercel.app`) on the production site. The main change ensures that, in production, the documentation base URL is canonicalized to the main site’s `/docs` path, regardless of the preview docs origin. A new test was also added to verify this behavior.

**Production docs origin safety:**

* Updated `normalizeDocsBaseUrl` in `config.ts` to check if the docs base URL points to the preview origin; if so, and if the environment is production or the site host matches the production domain, it returns the canonical production docs URL instead.

**Testing:**

* Added a test in `config-variants.test.ts` to verify that, in production, the docs origin is always canonicalized to the main site’s `/docs` path.