### PR TITLE
ci: reduce Playwright setup overhead in PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 12
     # Require quality, test, and link validation jobs
     needs: [quality, test, link-validation]
     # Allow skipping when secrets-scan is conditional (not run on push events)
@@ -151,22 +151,10 @@ jobs:
             exit 1
           fi
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
-      - name: Start dev server
-        run: pnpm dev &
-
-      - name: Wait for server to be ready
-        run: npx wait-on http://localhost:3000
-
-      - name: Run E2E tests
-        run: pnpm test:e2e
-
   link-validation:
     name: link-validation
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [quality]
     permissions:
       contents: read
@@ -188,6 +176,14 @@ jobs:
 
       - name: Install deps (frozen)
         run: pnpm install --frozen-lockfile
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Registry validation
         run: pnpm registry:validate
@@ -217,7 +213,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [quality]
     permissions:
       contents: read
@@ -239,6 +235,14 @@ jobs:
 
       - name: Install deps (frozen)
         run: pnpm install --frozen-lockfile
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Run unit tests
         run: pnpm test:unit


### PR DESCRIPTION
## Summary

- Reduced repeated Playwright setup overhead in CI while preserving existing required checks.
- Removed duplicate Playwright E2E execution from `build` (build still depends on successful `quality`, `test`, and `link-validation`).
- Added Playwright browser cache restore (`~/.cache/ms-playwright`) in `test` and `link-validation`.
- Increased `test` and `link-validation` timeout to 20 minutes to absorb cold-run variability.
- Reduced `build` timeout to 12 minutes because duplicate E2E steps were removed.

## Rationale

- PR checks were showing prohibitive runtime and occasional cancellation in `ci / link-validation`.
- Root cause was repeated `Install Playwright browsers` downloads across multiple jobs, not the link checks themselves.
- This patch streamlines repeated setup without removing any quality/security enforcement gates.

## Evidence

- [ ] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional):
  - PR #114 `ci / link-validation` (job 82216142860): Playwright install ~10m38s; total job ~12m.
  - PR #120 `ci / link-validation` (job 82216828461): Playwright install ran ~14m58s then job cancelled.
  - PR #116 `ci / link-validation` (job 82201898386): Playwright install ~9m22s.

## Risk and impact

- Low-to-moderate CI workflow risk.
- Potential impact: stale cache edge cases; mitigated by lockfile-based cache key and restore fallback.
- No user-facing application behavior changes.

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [x] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any): Least-privilege job permissions remain unchanged.

## CI Status

- [ ] `ci / quality` passed (lint, format, typecheck)
- [ ] `ci / secrets-scan` passed (PR-only gate)
- [ ] `ci / test` passed (unit + E2E tests)
- [ ] `ci / link-validation` passed (registry + evidence links; Stage 3.5)
- [ ] `ci / build` passed (depends on quality, test, link-validation)
- [ ] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)
- Notes:
  - CI behavior change is operationally scoped; can be documented in runbooks if team prefers explicit CI timing guidance.
