### PR TITLE
Feat/phase2a1 materiality

### DIFF
--- a/src/app/design-tokens-preview/page.tsx
+++ b/src/app/design-tokens-preview/page.tsx
@@ -31,6 +31,36 @@ export default function DesignTokensPreviewPage() {
           production page structure.
         </p>
       </Panel>
+
+      {/* Dial alignment verification: multiple fixed values */}
+      <Panel label="DIAL ALIGNMENT VERIFICATION" variant="default">
+        <div className="flex flex-wrap items-end justify-start gap-8">
+          <div className="flex flex-col items-center">
+            <Dial value={0} />
+            <div className="type-label text-ink-muted mt-2">0</div>
+          </div>
+          <div className="flex flex-col items-center">
+            <Dial value={25} />
+            <div className="type-label text-ink-muted mt-2">25</div>
+          </div>
+          <div className="flex flex-col items-center">
+            <Dial value={50} />
+            <div className="type-label text-ink-muted mt-2">50</div>
+          </div>
+          <div className="flex flex-col items-center">
+            <Dial value={75} />
+            <div className="type-label text-ink-muted mt-2">75</div>
+          </div>
+          <div className="flex flex-col items-center">
+            <Dial value={100} />
+            <div className="type-label text-ink-muted mt-2">100</div>
+          </div>
+        </div>
+        <p className="type-caption text-ink-muted mt-6">
+          Verify: ticks align with needle at each value; dimensional bezel, recessed face, and
+          shadowed needle visible; accent arc highlights current zone (dark mode).
+        </p>
+      </Panel>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -157,15 +157,17 @@ body {
   font-weight: 500;
 }
 
-/* Subtle phosphor glow, active in dark mode only */
+/* Enhanced phosphor bloom glow for readout value in dark mode */
 .glow-accent {
   text-shadow: none;
 }
 
 html:not(.light) .glow-accent {
   text-shadow:
-    0 0 6px color-mix(in srgb, var(--accent) 28%, transparent),
-    0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
+    0 0 2px color-mix(in srgb, var(--accent) 80%, transparent),
+    0 0 6px color-mix(in srgb, var(--accent) 60%, transparent),
+    0 0 12px color-mix(in srgb, var(--accent) 40%, transparent),
+    0 0 20px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 @media (min-width: 640px) {

--- a/src/components/Dial.tsx
+++ b/src/components/Dial.tsx
@@ -15,7 +15,26 @@ export function Dial({ value, caption, className = "" }: DialProps) {
   return (
     <div className={`inline-flex flex-col items-center gap-2 ${className}`.trim()}>
       <svg width="86" height="86" viewBox="0 0 86 86" className="text-line" aria-hidden="true">
+        <defs>
+          {/* Gradient for bezel (top-left light source) */}
+          <linearGradient id="bezel-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="rgba(255, 255, 255, 0.15)" />
+            <stop offset="50%" stopColor="rgba(0, 0, 0, 0)" />
+            <stop offset="100%" stopColor="rgba(0, 0, 0, 0.25)" />
+          </linearGradient>
+          {/* Radial gradient for dimensional rivet/hub */}
+          <radialGradient id="hub-grad" cx="35%" cy="35%">
+            <stop offset="0%" stopColor="rgba(255, 255, 255, 0.3)" />
+            <stop offset="70%" stopColor="currentColor" />
+            <stop offset="100%" stopColor="rgba(0, 0, 0, 0.5)" />
+          </radialGradient>
+        </defs>
+
+        {/* Outer bezel ring with dimensional bevel */}
         <circle cx="43" cy="43" r="38" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <circle cx="43" cy="43" r="38" fill="url(#bezel-grad)" opacity="0.6" />
+
+        {/* Recessed face (inner circle with inset shadow) */}
         <circle
           cx="43"
           cy="43"
@@ -25,9 +44,34 @@ export function Dial({ value, caption, className = "" }: DialProps) {
           strokeWidth="1"
           opacity="0.6"
         />
+        {/* Inset shadow effect for recessed face */}
+        <circle
+          cx="43"
+          cy="43"
+          r="29.5"
+          fill="none"
+          stroke="rgba(0, 0, 0, 0.2)"
+          strokeWidth="1"
+          opacity="0.8"
+        />
 
+        {/* Optional: Subtle accent value-arc highlighting current value zone (dark mode) */}
+        <circle
+          cx="43"
+          cy="43"
+          r="25"
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="1"
+          strokeDasharray="157 628"
+          strokeDashoffset={157 - (safeValue / 100) * 157}
+          opacity="0.15"
+          strokeLinecap="round"
+        />
+
+        {/* Ticks: rotated 90 degrees counter-clockwise to align with needle sweep */}
         {Array.from({ length: 11 }).map((_, idx) => {
-          const tickAngle = (-120 + idx * 24) * (Math.PI / 180);
+          const tickAngle = (-210 + idx * 24) * (Math.PI / 180);
           const x1 = 43 + Math.cos(tickAngle) * 27;
           const y1 = 43 + Math.sin(tickAngle) * 27;
           const x2 = 43 + Math.cos(tickAngle) * 33;
@@ -46,17 +90,38 @@ export function Dial({ value, caption, className = "" }: DialProps) {
           );
         })}
 
-        <line
-          x1="43"
-          y1="43"
-          x2="43"
-          y2="16"
-          stroke="var(--accent)"
-          strokeWidth="2"
-          strokeLinecap="round"
-          transform={`rotate(${angle} 43 43)`}
-        />
-        <circle cx="43" cy="43" r="3" fill="var(--rivet)" />
+        {/* Needle with subtle shadow for dimensional effect */}
+        <g>
+          {/* Needle shadow */}
+          <line
+            x1="43"
+            y1="43"
+            x2="43"
+            y2="16"
+            stroke="rgba(0, 0, 0, 0.3)"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            transform={`rotate(${angle + 1.5} 43 43)`}
+            opacity="0.4"
+          />
+          {/* Main needle */}
+          <line
+            x1="43"
+            y1="43"
+            x2="43"
+            y2="16"
+            stroke="var(--accent)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            transform={`rotate(${angle} 43 43)`}
+          />
+        </g>
+
+        {/* Center pivot hub: larger and dimensional */}
+        <circle cx="43" cy="43" r="5" fill="url(#hub-grad)" />
+        <circle cx="43" cy="43" r="5" fill="var(--rivet)" opacity="0.7" />
+        {/* Highlight on hub for dimension */}
+        <circle cx="41" cy="41" r="1.5" fill="rgba(255, 255, 255, 0.4)" />
       </svg>
 
       {caption ? <div className="type-label text-ink-muted">{caption}</div> : null}

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -25,10 +25,18 @@ export function Panel({
   className = "",
 }: PanelProps) {
   const variantClass = variant === "inset" ? "bg-surface-2" : "bg-surface";
+  const sheenStyle =
+    variant === "default"
+      ? {
+          backgroundImage:
+            "linear-gradient(135deg, rgba(255, 255, 255, 0.26) 0%, rgba(255, 255, 255, 0.11) 24%, rgba(255, 255, 255, 0.03) 48%, transparent 72%)",
+        }
+      : undefined;
 
   return (
     <section
       className={`border-line text-ink relative rounded-md border px-5 pt-6 pb-5 ${variantClass} ${className}`.trim()}
+      style={sheenStyle}
     >
       {label ? <div className="type-label text-ink-muted mb-4">{label}</div> : null}
 


### PR DESCRIPTION
## Summary
This pull request enhances the visual fidelity and usability of the `Dial` component and its preview, focusing on improved realism, accessibility for alignment verification, and a more polished UI. The changes include significant SVG improvements for dimensional effects, a new dial alignment verification panel, and subtle UI refinements for both dark and light modes.

**Dial component visual and functional improvements:**

* Added SVG gradients and effects to the `Dial` component for a more realistic bezel, recessed face, and dimensional hub, including new `<defs>` for gradients and additional circles for shadows and highlights. [[1]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17R18-R37) [[2]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17R47-R74) [[3]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17L59-R124)
* Enhanced the needle with a subtle shadow for depth, and adjusted the tick marks' rotation for better alignment with the needle sweep. [[1]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17R47-R74) [[2]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17R93-R107)

**Design tokens preview enhancements:**

* Introduced a new "DIAL ALIGNMENT VERIFICATION" panel in `DesignTokensPreviewPage`, displaying multiple dials at fixed values (0, 25, 50, 75, 100) to facilitate visual verification of tick/needle alignment and dimensional effects.

**UI and style refinements:**

* Updated the `.glow-accent` CSS for a more pronounced phosphor bloom effect in dark mode, improving the visual emphasis of readout values.
* Added a subtle sheen gradient background to default variant `Panel` components for a more polished, tactile appearance.

## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional):

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [x] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [x] All CI Checks passed:
  - [x] `ci / quality` passed (lint, format, typecheck)
  - [x] `ci / secrets-scan` passed (PR-only gate)
  - [x] `ci / test` passed (unit + E2E tests)
  - [x] `ci / link-validation` passed (registry + evidence links)
  - [x] `ci / build` passed (depends on quality, test, link-validation)
  - [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)

- Notes:
