### PR TITLE
feat: enhance Dial and Panel components with improved styles and effects

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -170,6 +170,16 @@ html:not(.light) .glow-accent {
     0 0 20px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
+.dial-accent-arc {
+  opacity: 0.42;
+}
+
+html:not(.light) .dial-accent-arc {
+  filter: drop-shadow(0 0 2px color-mix(in srgb, var(--accent) 80%, transparent))
+    drop-shadow(0 0 5px color-mix(in srgb, var(--accent) 58%, transparent))
+    drop-shadow(0 0 10px color-mix(in srgb, var(--accent) 34%, transparent));
+}
+
 @media (min-width: 640px) {
   .type-display {
     font-size: 3.5rem;

--- a/src/components/Dial.tsx
+++ b/src/components/Dial.tsx
@@ -39,7 +39,7 @@ export function Dial({ value, caption, className = "" }: DialProps) {
           cx="43"
           cy="43"
           r="30"
-          fill="none"
+          fill="color-mix(in srgb, var(--bg) 28%, var(--surface) 72%)"
           stroke="currentColor"
           strokeWidth="1"
           opacity="0.6"
@@ -50,32 +50,54 @@ export function Dial({ value, caption, className = "" }: DialProps) {
           cy="43"
           r="29.5"
           fill="none"
-          stroke="rgba(0, 0, 0, 0.2)"
-          strokeWidth="1"
+          stroke="rgba(0, 0, 0, 0.34)"
+          strokeWidth="1.4"
+          opacity="0.95"
+        />
+        <circle
+          cx="43"
+          cy="43"
+          r="27.75"
+          fill="none"
+          stroke="rgba(0, 0, 0, 0.16)"
+          strokeWidth="2.2"
+          opacity="0.75"
+        />
+        <circle
+          cx="42.2"
+          cy="42.2"
+          r="28.4"
+          fill="none"
+          stroke="rgba(255, 255, 255, 0.08)"
+          strokeWidth="0.9"
           opacity="0.8"
         />
 
         {/* Optional: Subtle accent value-arc highlighting current value zone (dark mode) */}
         <circle
+          className="dial-accent-arc"
           cx="43"
           cy="43"
           r="25"
           fill="none"
           stroke="var(--accent)"
-          strokeWidth="1"
+          strokeWidth="1.8"
           strokeDasharray="157 628"
           strokeDashoffset={157 - (safeValue / 100) * 157}
-          opacity="0.15"
+          opacity="0.42"
           strokeLinecap="round"
         />
 
         {/* Ticks: rotated 90 degrees counter-clockwise to align with needle sweep */}
         {Array.from({ length: 11 }).map((_, idx) => {
+          const isMajorTick = idx % 5 === 0;
           const tickAngle = (-210 + idx * 24) * (Math.PI / 180);
-          const x1 = 43 + Math.cos(tickAngle) * 27;
-          const y1 = 43 + Math.sin(tickAngle) * 27;
-          const x2 = 43 + Math.cos(tickAngle) * 33;
-          const y2 = 43 + Math.sin(tickAngle) * 33;
+          const innerRadius = isMajorTick ? 25.5 : 26.5;
+          const outerRadius = isMajorTick ? 34.5 : 33.5;
+          const x1 = 43 + Math.cos(tickAngle) * innerRadius;
+          const y1 = 43 + Math.sin(tickAngle) * innerRadius;
+          const x2 = 43 + Math.cos(tickAngle) * outerRadius;
+          const y2 = 43 + Math.sin(tickAngle) * outerRadius;
           return (
             <line
               key={idx}
@@ -84,8 +106,9 @@ export function Dial({ value, caption, className = "" }: DialProps) {
               x2={x2}
               y2={y2}
               stroke="currentColor"
-              strokeWidth="1"
-              opacity={idx % 5 === 0 ? 0.9 : 0.55}
+              strokeWidth={isMajorTick ? 1.55 : 1.2}
+              strokeLinecap="round"
+              opacity={isMajorTick ? 0.98 : 0.78}
             />
           );
         })}
@@ -98,11 +121,11 @@ export function Dial({ value, caption, className = "" }: DialProps) {
             y1="43"
             x2="43"
             y2="16"
-            stroke="rgba(0, 0, 0, 0.3)"
-            strokeWidth="2.5"
+            stroke="rgba(0, 0, 0, 0.42)"
+            strokeWidth="3.2"
             strokeLinecap="round"
-            transform={`rotate(${angle + 1.5} 43 43)`}
-            opacity="0.4"
+            transform={`rotate(${angle + 2.25} 43 43) translate(1.1 1.4)`}
+            opacity="0.62"
           />
           {/* Main needle */}
           <line

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -25,18 +25,31 @@ export function Panel({
   className = "",
 }: PanelProps) {
   const variantClass = variant === "inset" ? "bg-surface-2" : "bg-surface";
-  const sheenStyle =
+  const panelStyle =
     variant === "default"
       ? {
           backgroundImage:
-            "linear-gradient(135deg, rgba(255, 255, 255, 0.26) 0%, rgba(255, 255, 255, 0.11) 24%, rgba(255, 255, 255, 0.03) 48%, transparent 72%)",
+            "linear-gradient(135deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.08) 18%, rgba(255, 255, 255, 0.02) 42%, transparent 70%), repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.02) 0 1px, transparent 1px 6px)",
+          boxShadow:
+            "inset 1px 1px 0 rgba(255, 255, 255, 0.08), inset -1px -1px 0 rgba(0, 0, 0, 0.34), 0 16px 28px rgba(0, 0, 0, 0.16), 0 5px 12px rgba(0, 0, 0, 0.2)",
         }
-      : undefined;
+      : {
+          backgroundImage:
+            "linear-gradient(135deg, rgba(255, 255, 255, 0.07) 0%, rgba(255, 255, 255, 0.02) 18%, transparent 48%)",
+          boxShadow:
+            "inset 2px 2px 3px rgba(0, 0, 0, 0.28), inset -1px -1px 0 rgba(255, 255, 255, 0.05), inset 0 10px 20px rgba(0, 0, 0, 0.14)",
+        };
+  const rivetStyle = {
+    background:
+      "radial-gradient(circle at 32% 30%, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.18) 18%, color-mix(in srgb, var(--rivet) 92%, transparent) 48%, color-mix(in srgb, var(--rivet) 65%, black) 78%, color-mix(in srgb, var(--rivet) 40%, black) 100%)",
+    boxShadow:
+      "inset -1px -1px 1px rgba(255, 255, 255, 0.18), inset 1.5px 1.5px 2px rgba(0, 0, 0, 0.4), 0.75px 1.25px 1.5px rgba(0, 0, 0, 0.35)",
+  } as const;
 
   return (
     <section
       className={`border-line text-ink relative rounded-md border px-5 pt-6 pb-5 ${variantClass} ${className}`.trim()}
-      style={sheenStyle}
+      style={panelStyle}
     >
       {label ? <div className="type-label text-ink-muted mb-4">{label}</div> : null}
 
@@ -44,12 +57,14 @@ export function Panel({
         ? rivetPositions.map((position) => (
             <span
               key={position}
-              className={`pointer-events-none absolute ${position}`}
+              className={`pointer-events-none absolute ${position} h-3 w-3 rounded-full`}
               aria-hidden="true"
+              style={rivetStyle}
             >
-              <svg width="6" height="6" viewBox="0 0 6 6" className="text-rivet" aria-hidden="true">
-                <circle cx="3" cy="3" r="2" fill="currentColor" />
-              </svg>
+              <span
+                className="absolute top-0.5 left-0.5 h-0.5 w-0.5 rounded-full"
+                style={{ backgroundColor: "rgba(255, 255, 255, 0.45)" }}
+              />
             </span>
           ))
         : null}


### PR DESCRIPTION
## Summary

This pull request focuses on visual and styling improvements to the `Dial` and `Panel` components, enhancing their appearance and depth, especially in dark mode. The changes include refined SVG rendering for the dial, improved accent and shadow effects, and a more realistic panel and rivet look.

**Dial component visual enhancements:**

* Added multiple new SVG circles to the `Dial` for layered shadow and highlight effects, and adjusted fill and stroke properties for more depth and subtlety. [[1]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17L42-R42) [[2]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17L53-R100)
* Enhanced tick marks by distinguishing major and minor ticks with different radii, stroke widths, and opacities, making the dial easier to read. [[1]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17L53-R100) [[2]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17L87-R111)
* Improved the accent arc's appearance (especially in dark mode) by introducing the `.dial-accent-arc` class, adjusting opacity, stroke width, and adding drop-shadow effects via CSS. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R173-R182) [[2]](diffhunk://#diff-f098253b3f7b330f9636a475726d94e0d64ad4085a3c675997ed899e61430f17L53-R100)
* Refined the needle rendering for better contrast and visual clarity, including changes to stroke color, width, opacity, and transformation.

**Panel component and rivet styling improvements:**

* Overhauled the `Panel` component's background and box-shadow styles for both default and inset variants, creating a more realistic, layered look.
* Redesigned the rivet appearance to use CSS gradients and shadows instead of SVG, resulting in a more metallic and three-dimensional effect.
## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional):

## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [x] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [ ] All CI Checks passed:
  - [x] `ci / quality` passed (lint, format, typecheck)
  - [x] `ci / secrets-scan` passed (PR-only gate)
  - [x] `ci / test` passed (unit + E2E tests)
  - [x] `ci / link-validation` passed (registry + evidence links)
  - [x] `ci / build` passed (depends on quality, test, link-validation)
  - [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)

- Notes:
