### PR TITLE
style: update eyebrow copy for clarity and consistency

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function HomePage() {
             {/* TODO(phase2c1-copy): Workshop decision pending - consider present-tense eyebrow variant. */}
             <p className="type-label text-ink-muted">
               Full-Stack Cloud Engineer | Next.js, React, Python, Java, C++ | Docker, AWS, Azure |
-              Architecting secure, reliable applications & bulletproof pipelines
+              Architect of secure, reliable applications & bulletproof pipelines
             </p>
 
             <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
@@ -47,7 +47,7 @@ export default function HomePage() {
               <br />
               <br />
               Because of my background in project management, I don&apos;t just write code in a
-              vacuum—I design architectures with business constraints, security compliance, and
+              vacuum.  I design architectures with business constraints, security compliance, and
               long-term reliability in mind. I specialize in building robust CI/CD pipelines that
               eliminate deployment anxiety and keep engineering teams moving fast.
             </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function HomePage() {
               <br />
               <br />
               Because of my background in project management, I don&apos;t just write code in a
-              vacuum.  I design architectures with business constraints, security compliance, and
+              vacuum. I design architectures with business constraints, security compliance, and
               long-term reliability in mind. I specialize in building robust CI/CD pipelines that
               eliminate deployment anxiety and keep engineering teams moving fast.
             </p>


### PR DESCRIPTION
## Summary

This pull request makes minor updates to the copy on the `HomePage` to improve clarity and readability. The changes focus on refining language in the professional summary and project management description.

Copy improvements:

* Updated the professional summary to use "Architect of secure, reliable applications & bulletproof pipelines" instead of "Architecting secure, reliable applications & bulletproof pipelines" for a more concise and present-tense description.
* Modified a sentence in the project management section to break up a long sentence and improve flow by replacing "I don't just write code in a vacuum—I design architectures..." with "I don't just write code in a vacuum. I design architectures...".
## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional):


## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [x] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [x] All CI Checks passed:
  - [x] `ci / quality` passed (lint, format, typecheck)
  - [x] `ci / secrets-scan` passed (PR-only gate)
  - [x] `ci / test` passed (unit + E2E tests)
  - [x] `ci / link-validation` passed (registry + evidence links)
  - [x] `ci / build` passed (depends on quality, test, link-validation)
  - [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)

- Notes:
