### PR TITLE
feat: add PerformanceMonitor component for enhanced performance tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { headers } from "next/headers";
 import "./globals.css";
 
 import { DOCS_BASE_URL, GITHUB_BASE_URL, LINKEDIN_URL, SITE_URL } from "@/lib/config";
+import { PerformanceMonitor } from "./performance-monitor";
 
 const APP_TITLE = "Bryce Seefieldt | Portfolio";
 const APP_DESCRIPTION =
@@ -162,6 +163,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           </div>
         </footer>
         <BackToTop />
+        <PerformanceMonitor />
         {enableTelemetry ? <Analytics /> : null}
         {enableTelemetry ? <SpeedInsights /> : null}
       </body>

--- a/src/app/performance-monitor.tsx
+++ b/src/app/performance-monitor.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function PerformanceMonitor() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const originalMeasure = performance.measure.bind(performance);
+
+    const wrappedMeasure: typeof performance.measure = function (
+      measureName: string,
+      startOrMeasureOptions?: string | PerformanceMeasureOptions,
+      endMark?: string,
+    ) {
+      try {
+        return originalMeasure(measureName, startOrMeasureOptions, endMark);
+      } catch (error: unknown) {
+        const err = error as Error;
+        if (err?.message?.includes("negative")) {
+          console.debug("Performance: timing issue (negative value), suppressed");
+          // Return a synthetic measure object to prevent breaking Speed Insights
+          return {
+            name: measureName,
+            entryType: "measure",
+            startTime: 0,
+            duration: 0,
+            toJSON: () => ({}),
+          } as PerformanceMeasure;
+        }
+        throw error;
+      }
+    };
+
+    performance.measure = wrappedMeasure;
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
This pull request introduces a new `PerformanceMonitor` component to the application to improve the handling of browser performance measurements and prevent errors from breaking analytics tools like Speed Insights. The main changes involve adding this component, integrating it into the root layout, and ensuring it gracefully handles certain performance timing issues.

**Performance monitoring improvements:**

* Added a new `PerformanceMonitor` component in `src/app/performance-monitor.tsx` that wraps the browser's `performance.measure` method to suppress and handle errors related to negative timing values, preventing them from breaking Speed Insights.
* Imported and rendered the `PerformanceMonitor` component in the root layout (`src/app/layout.tsx`) so that it is active across the application. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R12) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R166)

## Evidence

- [x] Local verify ran (recommended): `pnpm verify`
  - Or individually: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm audit`, `pnpm build`
- Links/screenshots (optional):


## Security

- [x] No secrets added
- [x] No sensitive endpoints/internal details added
- [ ] Local secret hygiene checked (lightweight pattern scan or pre-commit)
- Notes (if any):

## CI Status

- [x] All CI Checks passed:
  - [x] `ci / quality` passed (lint, format, typecheck)
  - [x] `ci / secrets-scan` passed (PR-only gate)
  - [x] `ci / test` passed (unit + E2E tests)
  - [x] `ci / link-validation` passed (registry + evidence links)
  - [x] `ci / build` passed (depends on quality, test, link-validation)
  - [x] `codeql` checks passed

## Documentation

- [ ] Dossier updated (if behavior/architecture changed)
- [ ] ADR added/updated (if decision is durable)
- [ ] Threat model updated (if surface area changed)
- [ ] Runbooks updated (if deploy/rollback/triage changed)

- Notes:
